### PR TITLE
"Success" banner/notification to replace success page

### DIFF
--- a/dashboard/static/css/style.css
+++ b/dashboard/static/css/style.css
@@ -114,6 +114,52 @@ form .form-text {
     }
 }
 
+.messages {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 1rem;
+}
+
+.messages>ul {
+	max-width: 1000px;
+	list-style-type: none;
+	margin: 0;
+    padding: 0;
+    display: inline;
+    flex-grow: 1;
+}
+
+.messages>ul>li {
+	text-align: center;
+	background-color: #d3d3d3;
+	padding: 1rem;
+	flex-grow: 1;
+	margin: 0.3rem;
+}
+
+.messages>ul>li.debug {
+    background-color: #BFBFBF;
+}
+
+.messages>ul>li.info {
+    background-color: #ADD8E6;
+}
+
+.messages>ul>li.success {
+    background-color: #90EE90;
+}
+
+.messages>ul>li.warning {
+    background-color: #FFA500;
+    color: #FFFFFF;
+}
+
+.messages>ul>li.error {
+    background-color: #FF0000;
+    color: #FFFFFF;
+}
+
 .green-button {
     font-weight: bold;
     text-transform: uppercase;

--- a/dashboard/templates/dashboard/base.html
+++ b/dashboard/templates/dashboard/base.html
@@ -38,6 +38,17 @@
         {% endblock %}
 
         <div class="container sawaliram-container flex-grow">
+            {% block notifications %}
+                {% if messages %}
+                <div class="messages">
+                    <ul>
+                        {% for message in messages %}
+                        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                {% endif %}
+            {% endblock %}
             {% block content %} {% endblock %}
         </div>
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -6,6 +6,7 @@ from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.models import Group
+from django.contrib import messages
 from django.db.models import Max, Subquery
 import pandas as pd
 from dashboard.models import (

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -122,6 +122,7 @@ def login_user(request):
 
     if user is not None:
         login(request, user)
+        messages.success(request, "Welcome back, %s!" % user.get_full_name())
         return redirect(request.POST.get('next', 'dashboard:dashboard_home'))
     else:
         return render(
@@ -172,6 +173,8 @@ def signup_user(request):
         volunteers.user_set.add(user)
 
         login(request, user)
+
+        messages.success(request, "Your account has been created. Welcome to the team!")
         return redirect('dashboard:dashboard_home')
 
 
@@ -265,14 +268,14 @@ def submit_questions(request):
     new_submission.submitted_by = request.user
     new_submission.save()
 
-    context = {
-        'number_of_questions_submitted': len(question_text_list),
-    }
 
-    return render(
-        request,
-        'dashboard/questions-submitted-successfully.html',
-        context)
+    if len(question_text_list) == 1:
+        msg = 'Your question has been submitted successfully!'
+    else:
+        msg = 'Your questions have been submitted successfully!'
+
+    messages.success(request, msg)
+    return redirect('dashboard:dashboard_home')
 
 
 def submit_excel_sheet(request):
@@ -369,7 +372,8 @@ def submit_excel_sheet(request):
     new_submission.submitted_by = request.user
     new_submission.save()
 
-    return render(request, 'dashboard/excel-submitted-successfully.html')
+    messages.success(request, 'Your Excel sheet has been submitted successfully!')
+    return redirect('dashboard:dashboard_home')
 
 
 def submit_curated_dataset(request):
@@ -436,7 +440,8 @@ def submit_curated_dataset(request):
     uncurated_submission_entry.curated = True
     uncurated_submission_entry.save()
 
-    return render(request, 'dashboard/excel-submitted-successfully.html')
+    messages.success(request, 'Your curated dataset has been uploaded successfully')
+    return redirect('dashboard:dashboard_home')
 
 
 def get_error_404_view(request, exception):


### PR DESCRIPTION
I've added the "successfully submitted" banner using Django's `messages` infrastructure.

However, I can't implement messaging for unmerged features (like #38) without messing up the commit log. If you merge either this or the others, I can do a rebase and implement the rest.