### PR TITLE
Update templates to use new base.html path

### DIFF
--- a/dashboard/templates/dashboard/404.html
+++ b/dashboard/templates/dashboard/404.html
@@ -1,5 +1,5 @@
 
-{% extends "dashboard/base.html" %}
+{% extends "public_website/base.html" %}
 
 {% block title %} Page Not Found | Sawaliram {% endblock %}
 

--- a/dashboard/templates/dashboard/answer-question.html
+++ b/dashboard/templates/dashboard/answer-question.html
@@ -1,4 +1,4 @@
-{% extends "dashboard/base.html" %}
+{% extends "public_website/base.html" %}
 
 {% load static %}
 

--- a/dashboard/templates/dashboard/answer-questions-list.html
+++ b/dashboard/templates/dashboard/answer-questions-list.html
@@ -1,4 +1,4 @@
-{% extends "dashboard/base.html" %}
+{% extends "public_website/base.html" %}
 
 {% block title %} Answer Questions | Sawaliram {% endblock %}
 

--- a/dashboard/templates/dashboard/curate-data.html
+++ b/dashboard/templates/dashboard/curate-data.html
@@ -1,4 +1,4 @@
-{% extends "dashboard/base.html" %}
+{% extends "public_website/base.html" %}
 
 {% block title %} Curate Data | Sawaliram {% endblock %}
 

--- a/dashboard/templates/dashboard/encode-data.html
+++ b/dashboard/templates/dashboard/encode-data.html
@@ -1,4 +1,4 @@
-{% extends "dashboard/base.html" %}
+{% extends "public_website/base.html" %}
 
 {% block title %} Encode Data | Sawaliram {% endblock %}
 

--- a/dashboard/templates/dashboard/view-questions-old.html
+++ b/dashboard/templates/dashboard/view-questions-old.html
@@ -1,4 +1,4 @@
-{% extends "dashboard/base.html" %}
+{% extends "public_website/base.html" %}
 
 {% block title %} View Questions | Sawaliram {% endblock %}
 

--- a/dashboard/templates/dashboard/work-in-progress.html
+++ b/dashboard/templates/dashboard/work-in-progress.html
@@ -1,4 +1,4 @@
-{% extends "dashboard/base.html" %}
+{% extends "public_website/base.html" %}
 
 {% block title %} Work In Progress | Sawaliram {% endblock %}
 


### PR DESCRIPTION
Template has moved from `dashboard` to `public_website` app, but child templates were not updated accordingly so were failing with a `TemplateNotFoud` error. This commits fixes that issue.