### PR TITLE
Fix image size on attaching to editor

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -142,6 +142,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
+DATA_UPLOAD_MAX_MEMORY_SIZE = 20971520
+
 if os.environ.get('environment') == 'heroku':
     import django_heroku
     django_heroku.settings(locals())

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -885,6 +885,8 @@ class EditArticleView(View):
             'article': article,
             'grey_background': 'True',
             'language_choices': LANGUAGE_CHOICES,
+            'page_title': 'Write Article',
+            'enable_breadcrumbs': 'Yes'
         }
 
         article.title = request.POST.get('title')
@@ -895,7 +897,7 @@ class EditArticleView(View):
 
             article.save()
 
-            messages.info(request, self.draft_save_message)
+            messages.success(request, self.draft_save_message)
 
             # if submitted, go back to reviwe page
             if article.is_submitted:

--- a/public_website/static/css/style.css
+++ b/public_website/static/css/style.css
@@ -1520,6 +1520,16 @@ h1.dashboard-home-greeting {
     padding: 0.8rem;
 }
 
+.rich-text-form .ql-editor p {
+    margin-bottom: 1rem;   
+}
+
+.rich-text-form .ql-editor img {
+    max-width: 70%;
+    display: block;
+    margin: 0 auto;
+}
+
 .rich-text-form  .ql-container.ql-snow {
     border: none;
 }

--- a/public_website/templates/public_website/base.html
+++ b/public_website/templates/public_website/base.html
@@ -6,14 +6,15 @@
 
         {% load static %}
         <link rel="shortcut icon" type="image/png" href="{% static 'icons/favicon.ico' %}"/>
+
+        {% block head_includes %} {% endblock %}
+        
         <link rel="stylesheet" href="{% static 'css/reboot.css' %}">
         <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
         <link rel="stylesheet" href="{% static 'css/style.css' %}">
 
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.4.1/css/all.css" integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz" crossorigin="anonymous">
         <link href="https://fonts.googleapis.com/css?family=Noto+Sans:400,400i,700,700i&display=swap&subset=latin-ext" rel="stylesheet">
-
-        {% block head_includes %} {% endblock %}
 
         <title>{% block title %} {% endblock %}</title>
     </head>


### PR DESCRIPTION
Fixes #166 
Add margin to margin `<p>` elements
Fix success message popup styling on saving a draft `Article`
Add missing breadcrumbs after saving draft `Article`