### PR TITLE
Translation Tweaks

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -130,9 +130,23 @@ USE_L10N = True
 
 USE_TZ = True
 
-# Possible languages available in this website
-# (used for models, language fields, etc.)
+# Possible site languages available in this website
+# Buttons, menus, and general interface should be
+# available in the following languages
 LANGUAGES = [
+    ('en', 'English'),
+    ('hi', 'हिंदी'),
+]
+
+
+# Possible languages for content on this website
+# These are the language options for questions, answers,
+# translations, articles, etc.
+#
+# TODO: move this elsewhere to make it database-based
+# and easily updatable
+CONTENT_LANGUAGES = [
+    ('bn', 'বাংলা'),
     ('en', 'English'),
     ('hi', 'हिंदी'),
     ('mr', 'मराठी'),

--- a/dashboard/mixins/translations.py
+++ b/dashboard/mixins/translations.py
@@ -218,7 +218,7 @@ def translatable(cls):
         langs_dedup.sort()
 
         languages = [
-            (lang, dict(settings.LANGUAGES).get(lang, lang))
+            (lang, dict(settings.CONTENT_LANGUAGES).get(lang, lang))
             for lang in langs_dedup
         ]
 

--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -299,22 +299,15 @@ class AnswerTranslation(DraftableModel, TranslationMixin):
         '''
 
         if self.is_published:
-            return '?'.join([
+            return '?lang='.join([
                 reverse(
-                    'public_website:set-language',
+                    'public_website:view-answer',
                     kwargs={
-                        'language': self.language,
+                        'question_id': self.source.question_id.id,
+                        'answer_id': self.source.id,
                     }
                 ),
-                urlencode({
-                    'next': reverse(
-                        'public_website:view-answer',
-                        kwargs={
-                            'question_id': self.source.question_id.id,
-                            'answer_id': self.source.id,
-                        }
-                    ),
-                }),
+                self.language
             ])
         elif self.is_submitted:
             return reverse(
@@ -342,17 +335,6 @@ class DraftAnswerTranslation(
     class Meta:
         proxy = True
 
-    def get_absolute_url(self):
-        return reverse(
-            'dashboard:edit-answer-translation',
-            kwargs={
-                'answer': self.source.id,
-                'source': self.source.question_id.id,
-                'lang_from': self.source.language,
-                'lang_to': self.language,
-            }
-        )
-
 class SubmittedAnswerTranslation(
     AnswerTranslation.get_submitted_model(),
     AnswerTranslation,
@@ -361,13 +343,6 @@ class SubmittedAnswerTranslation(
     class Meta:
         proxy = True
 
-    def get_absolute_url(self):
-        return reverse(
-            'dashboard:review-answer-translation',
-            kwargs={
-                'pk': self.id,
-            }
-        )
     def get_publish_url(self):
         return reverse(
             'dashboard:publish-answer-translation',
@@ -383,18 +358,6 @@ class PublishedAnswerTranslation(
     objects = PublishedDraftableManager()
     class Meta:
         proxy = True
-
-    def get_absolute_url(self):
-        return reverse(
-            'dashboard:edit-answer-translation',
-            kwargs={
-                'answer': self.source.id,
-                'source': self.source.question_id.id,
-                'lang_from': self.source.language,
-                'lang_to': self.language,
-            }
-        )
-
 
 class AnswerCredit(models.Model):
     """Define the data model for answer and article credits"""
@@ -687,21 +650,14 @@ class ArticleTranslation(DraftableModel, TranslationMixin):
         '''
 
         if self.is_published:
-            return '?'.join([
+            return '?lang='.join([
                 reverse(
-                    'public_website:set-language',
+                    'public_website:view-article',
                     kwargs={
-                        'language': self.language,
+                        'article': self.source.id,
                     }
                 ),
-                urlencode({
-                    'next': reverse(
-                        'public_website:view-article',
-                        kwargs={
-                            'article': self.source.id,
-                        }
-                    ),
-                }),
+                self.language,
             ])
         elif self.is_submitted:
             return reverse(

--- a/dashboard/templates/dashboard/translations/answer_edit.html
+++ b/dashboard/templates/dashboard/translations/answer_edit.html
@@ -52,7 +52,7 @@
   <input type="hidden" name="answer-text" value="{{ answer.answer_text }}" />
   <button type="submit" name="mode" value="submit" class="btn btn-primary">Submit translation</button>
   <button type="submit" name="mode" value="draft" class="btn btn-primary-hollow">Save Draft</button>
-  <a href="{# url 'dashboard:delete-answer' object.id #}" class="text-danger float-right" data-toggle="tooltip" data-placement="left" title="Delete article">
+  <a href="{% url 'dashboard:delete-answer-translation' object.id %}" class="text-danger float-right" data-toggle="tooltip" data-placement="left" title="Delete translation">
     <i class="fas fa-trash"></i>
   </a>
 </footer>

--- a/dashboard/templates/dashboard/translations/article_edit.html
+++ b/dashboard/templates/dashboard/translations/article_edit.html
@@ -21,7 +21,7 @@
   <input type="hidden" name="{{ form.body.name }}" value="{{ form.body.value }}" />
   <button type="submit" name="mode" value="submit" class="btn btn-primary">Submit translation</button>
   <button type="submit" name="mode" value="draft" class="btn btn-primary-hollow">Save Draft</button>
-  <a href="{# url 'dashboard:delete-article' object.id #}" class="text-danger float-right" data-toggle="tooltip" data-placement="left" title="Delete article">
+  <a href="{% url 'dashboard:delete-article-translation' object.id %}" class="text-danger float-right" data-toggle="tooltip" data-placement="left" title="Delete translation">
     <i class="fas fa-trash"></i>
   </a>
 </footer>

--- a/dashboard/templates/dashboard/translations/base_edit.html
+++ b/dashboard/templates/dashboard/translations/base_edit.html
@@ -32,7 +32,7 @@
         </select>
         <span><label for="lang_to" class="fas fa-arrow-right"></label></span>
         <select id="lang_to" name="lang_to" class="input-plain text-center" style="ml-auto">
-          {% for value, label in language_choices %}
+          {% for value, label in content_language_choices %}
           <option value="{{ value }}"{% if value == object.language %} selected{% endif %}>{{ label }}</option>
           {% endfor %}
         </select>

--- a/dashboard/templates/dashboard/translations/base_edit.html
+++ b/dashboard/templates/dashboard/translations/base_edit.html
@@ -54,6 +54,10 @@
 
 {% endblock %}
 
+{% block script_includes %}
+<script src="{% static 'js/quill-blot-formatter.min.js' %}"></script>
+{% endblock %}
+
 {% block footer %}
 <script>
     setupQuillEditor({

--- a/dashboard/templatetags/to_language_name.py
+++ b/dashboard/templatetags/to_language_name.py
@@ -11,4 +11,4 @@ register = template.Library()
 @register.filter
 @stringfilter
 def to_language_name(value):
-    return dict(settings.LANGUAGES).get(value, value)
+    return dict(settings.CONTENT_LANGUAGES).get(value, value)

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1207,11 +1207,11 @@ class TranslationLanguagesForm(forms.Form):
     the translation.
     '''
 
-    lang_from = forms.ChoiceField(choices=settings.LANGUAGES,
+    lang_from = forms.ChoiceField(choices=settings.CONTENT_LANGUAGES,
         widget=forms.Select(attrs={
             'class': 'custom-select btn-primary',
         }))
-    lang_to = forms.ChoiceField(choices=settings.LANGUAGES  ,
+    lang_to = forms.ChoiceField(choices=settings.CONTENT_LANGUAGES  ,
         widget=forms.Select(attrs={
             'class': 'custom-select btn-primary',
         }))
@@ -1233,7 +1233,7 @@ class BaseStartTranslation(FormView):
         # Decide language options
         available_languages = self.source.list_available_languages()
         unavailable_languages = []
-        for l in settings.LANGUAGES:
+        for l in settings.CONTENT_LANGUAGES:
             if l not in available_languages:
                 unavailable_languages.append(l)
 
@@ -1337,7 +1337,7 @@ class BaseEditTranslation(UpdateView):
         '''
 
         # Check validity of languages
-        valid_languages = [l[0] for l in settings.LANGUAGES]
+        valid_languages = [l[0] for l in settings.CONTENT_LANGUAGES]
         lang_from = self.kwargs.get('lang_from')
         lang_to = self.kwargs.get('lang_to')
         user = self.request.user

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1466,6 +1466,12 @@ class BaseEditTranslation(UpdateView):
         except self.model.MultipleObjectsReturned:
             return redirect(self.get_conflict_url())
 
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context['content_language_choices'] = settings.CONTENT_LANGUAGES
+
+        return context
+
 # TODO: new view for "you have multiple drafts for this answer in this
 # language, please choose one".
 

--- a/public_website/templates/public_website/article.html
+++ b/public_website/templates/public_website/article.html
@@ -1,5 +1,7 @@
 {% extends 'public_website/base.html' %}
 
+{% load to_language_name %}
+
 {% block title %}{{ article.tr_title }} | Sawaliram{% endblock %}
 
 {% block content %}
@@ -17,6 +19,18 @@
     </p>
     {% if article.is_translated %}
     <p>Translated by <a href="{% url 'public_website:user-profile' article.translation.translator.id %}" class="text-secondary">{{ article.translation.translator.get_full_name }}</a></p>
+    {% endif %}
+    {% if article.translations %}
+    <div class="dropdown">
+      <button class="btn btn-secondary btn-small dropdown-toggle" type="button" id="translationSelectorButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Read article in: {{ article.tr_language|to_language_name }}
+      </button>
+      <div class="dropdown-menu" aria-labelledby="translationSelectorButton">
+        {% for lang, language in article.list_available_languages %}
+        <a class="dropdown-item" href="{{ request.get_base_path }}?lang={{ lang }}">{{ language }}</a>
+        {% endfor %}
+      </div>
+    </div>
     {% endif %}
   </header>
   <section class="article-body col-sm-6">

--- a/public_website/templates/public_website/base.html
+++ b/public_website/templates/public_website/base.html
@@ -233,5 +233,6 @@
         <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
         {% block script_includes %} {% endblock %}
         <script src="{% static 'js/script.js' %}"></script>
+        {% block footer %}{% endblock %}
     </body>
 </html>

--- a/public_website/templates/public_website/search.html
+++ b/public_website/templates/public_website/search.html
@@ -1,5 +1,7 @@
 {% extends "public_website/base.html" %}
 
+{% load to_language_name %}
+
 {% block title %} {{ page_title }} | Sawaliram {% endblock %}
 
 {% block content %}
@@ -54,7 +56,7 @@
                 <button class="btn open-filter" data-target="#filterLanguages" aria-expanded="true" aria-controls="filter-languages">Languages</button>
                 <div class="category-options-list" id="filterLanguages">
                     {% for language in languages %}
-                    <button class="btn category-option {% if language.language in languages_to_filter_by %}active{% endif %}" data-param="language" data-value="{{ language.language|urlencode }}">{{ language.language|capfirst }}</button>
+                    <button class="btn category-option {% if language.language in languages_to_filter_by %}active{% endif %}" data-param="language" data-value="{{ language.language|urlencode }}">{{ language.language|to_language_name }}</button>
                     {% endfor %}
                 </div>
             </div>

--- a/public_website/templates/public_website/view-answer.html
+++ b/public_website/templates/public_website/view-answer.html
@@ -4,6 +4,7 @@
 
 {% load static %}
 {% load render_linebreaks %}
+{% load to_language_name %}
 
 {% block content %}
 
@@ -71,6 +72,18 @@
             </span>
             {% endif %}
         </div>
+        {% if answer.translations %}
+        <div class="dropdown">
+          <button class="btn btn-secondary btn-small dropdown-toggle" type="button" id="translationSelectorButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Read answer in: {{ answer.tr_language|to_language_name }}
+          </button>
+          <div class="dropdown-menu" aria-labelledby="translationSelectorButton">
+            {% for lang, language in answer.list_available_languages %}
+            <a class="dropdown-item" href="{{ request.get_base_path }}?lang={{ lang }}">{{ language }}</a>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
     </div>
     <div class="answer-text-wrapper">
         <div class="answer-text">

--- a/public_website/views.py
+++ b/public_website/views.py
@@ -275,10 +275,10 @@ class ViewAnswer(View):
         answer = Answer.objects.get(pk=answer_id)
 
         # Set languages
-        preferred_language = request.session.get('lang',
-            settings.DEFAULT_LANGUAGE)
-        question.set_language(preferred_language)
-        answer.set_language(preferred_language)
+        preferred_language = request.GET.get('lang')
+        if preferred_language:
+            question.set_language(preferred_language)
+            answer.set_language(preferred_language)
 
         grey_background = 'True' if request.user.is_authenticated else 'False'
 
@@ -311,14 +311,20 @@ class ArticleView(View):
 
         # Set slug if required
         if slug != article.get_slug():
-            return redirect(
-                'public_website:view-article',
-                slug=article.get_slug(),
-                article=article.id
-            )
+            return redirect('?'.join([
+                reverse(
+                    'public_website:view-article',
+                    kwargs={
+                        'slug': article.get_slug(),
+                        'article': article.id,
+                    }
+                ),
+                request.GET.urlencode(),
+            ]))
 
         # Populate with language
-        article.set_language(request.session.get('lang', settings.DEFAULT_LANGUAGE))
+        lang = request.GET.get('lang')
+        if lang: article.set_language(lang)
 
         context = {
             'article': article,


### PR DESCRIPTION
Some tweaks and updates to the Translations module:

- [x] Decouple site languages from content languages
- [x] Allow users to select which language they want to view an answer or article in (translation selection)
- [x] Minor tweaks and bugfixes
    - [x] Quill editor not working after blot formatter activation
    - [x] Search page displays language codes ("en") instead of names ("English")
    - [x] "Delete translation" button in editor was not enabled