### PR TITLE
Make public_website translatable

### DIFF
--- a/public_website/templates/public_website/article.html
+++ b/public_website/templates/public_website/article.html
@@ -1,8 +1,9 @@
 {% extends 'public_website/base.html' %}
 
+{% load i18n %}
 {% load to_language_name %}
 
-{% block title %}{{ article.tr_title }} | Sawaliram{% endblock %}
+{% block title %}{{ article.tr_title }} | {% trans 'Sawaliram' %}{% endblock %}
 
 {% block content %}
 
@@ -18,12 +19,12 @@
       <a href="{% url 'public_website:user-profile' article.author.id %}" class="text-secondary">{{ article.author.get_full_name }}</a>
     </p>
     {% if article.is_translated %}
-    <p>Translated by <a href="{% url 'public_website:user-profile' article.translation.translator.id %}" class="text-secondary">{{ article.translation.translator.get_full_name }}</a></p>
+    <p>{% trans 'Translated by' %} <a href="{% url 'public_website:user-profile' article.translation.translator.id %}" class="text-secondary">{{ article.translation.translator.get_full_name }}</a></p>
     {% endif %}
     {% if article.translations %}
     <div class="dropdown">
       <button class="btn btn-secondary btn-small dropdown-toggle" type="button" id="translationSelectorButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        Read article in: {{ article.tr_language|to_language_name }}
+        {% trans 'Read article in' %}: {{ article.tr_language|to_language_name }}
       </button>
       <div class="dropdown-menu" aria-labelledby="translationSelectorButton">
         {% for lang, language in article.list_available_languages %}

--- a/public_website/templates/public_website/base.html
+++ b/public_website/templates/public_website/base.html
@@ -193,7 +193,7 @@
                             <a href="{% url 'dashboard:review-answers' %}">{% trans 'Review Answers' %}</a> >
                         {% endif %}
                         {% if page_title == 'Review Article' %}
-                            <a href="{% url 'dashboard:manage-content' %}">Manage Content</a> >
+                            <a href="{% url 'dashboard:manage-content' %}">{% trans 'Manage Content' %}</a> >
                         {% endif %}
                     {% endif %}
                     {{ page_title }}

--- a/public_website/templates/public_website/search.html
+++ b/public_website/templates/public_website/search.html
@@ -1,59 +1,60 @@
 {% extends "public_website/base.html" %}
 
+{% load i18n %}
 {% load to_language_name %}
 
-{% block title %} {{ page_title }} | Sawaliram {% endblock %}
+{% block title %} {{ page_title }} | {% trans 'Sawaliram' %}{% endblock %}
 
 {% block content %}
 <div class="search-container">
     <div class="mobile-filter-controls">
-        <button class="filter-button">Filters</button>
-        <button class="sort-by-button">Sort By</button>
+        <button class="filter-button">{% trans 'Filters' %}</button>
+        <button class="sort-by-button">{% trans 'Sort By' %}</button>
     </div>
     <div class="filter-sidebar">
         <div class="filter-head">
-            <span><b>Filters</b></span>
-            <button class="btn clear-all">Clear All</button>
+            <span><b>{% trans 'Filters' %}</b></span>
+            <button class="btn clear-all">{% trans 'Clear All' %}</button>
         </div>
         <div class="filter-list">
-            {% if page_title == 'Search' %}
+            {% if page_title == _('Search') %}
             <div class="filter-category">
                 <button class="btn open-filter" data-target="#filterCategories" aria-expanded="true" aria-controls="filter-categories">Category</button>
                 <div class="category-options-list" id="filterCategories">
-                    <button class="btn category-option {% if 'questions' in active_categories %}active{% endif %} no-fun" data-param="category" data-value="questions">Questions</button>
-                    <button class="btn category-option" data-param="category" data-value="articles" disabled>Articles</button>
-                    <button class="btn category-option" data-param="category" data-value="research" disabled>Research</button>
-                    <button class="btn category-option" data-param="category" data-value="resources" disabled>Resources</button>
+                    <button class="btn category-option {% if 'questions' in active_categories %}active{% endif %} no-fun" data-param="category" data-value="questions">{% trans 'Questions' %}</button>
+                    <button class="btn category-option" data-param="category" data-value="articles" disabled>{% trans 'Articles' %}</button>
+                    <button class="btn category-option" data-param="category" data-value="research" disabled>{% trans 'Research' %}</button>
+                    <button class="btn category-option" data-param="category" data-value="resources" disabled>{% trans 'Resources' %}</button>
                 </div>
             </div>
             {% endif %}
-            {% if page_title == 'Search' or page_title == 'View Questions' %}
+            {% if page_title == _('Search') or page_title == _('View Questions') %}
             <div class="filter-category">
-                <button class="btn open-filter" data-target="#filterCategories" aria-expanded="true" aria-controls="filter-categories">Questions</button>
+                <button class="btn open-filter" data-target="#filterCategories" aria-expanded="true" aria-controls="filter-categories">{% trans 'Questions' %}</button>
                 <div class="category-options-list" id="filterCategories">
-                    <button class="btn category-option {% if 'answered' in question_categories %}active{% endif %}" data-param="questions" data-value="answered">Answered</button>
-                    <button class="btn category-option {% if 'unanswered' in question_categories %}active{% endif %}" data-param="questions" data-value="unanswered">Unanswered</button>
+                    <button class="btn category-option {% if 'answered' in question_categories %}active{% endif %}" data-param="questions" data-value="answered">{% trans 'Answered' %}</button>
+                    <button class="btn category-option {% if 'unanswered' in question_categories %}active{% endif %}" data-param="questions" data-value="unanswered">{% trans 'Unanswered' %}</button>
                 </div>
             </div>
             {% endif %}
             <div class="filter-category">
-                <button class="btn open-filter" data-target="#filterSubjects" aria-expanded="true" aria-controls="filter-subjects">Subjects</button>
+                <button class="btn open-filter" data-target="#filterSubjects" aria-expanded="true" aria-controls="filter-subjects">{% trans 'Subjects' %}</button>
                 <div class="category-options-list" id="filterSubjects">
                     {% for subject in subjects %}
-                    <button class="btn category-option {% if subject in subjects_to_filter_by %}active{% endif %} {% if subject|length > 11 %}long-title{% endif %}" data-param="subject" data-value="{{ subject|urlencode }}" {% if subject not in available_subjects %}disabled{% endif %}>{{ subject|capfirst }}</button>
+                    <button class="btn category-option {% if subject in subjects_to_filter_by %}active{% endif %} {% if subject|length > 11 %}long-title{% endif %}" data-param="subject" data-value="{{ subject|urlencode }}" {% if subject not in available_subjects %}disabled{% endif %}>{% trans subject %}</button>
                     {% endfor %}
                 </div>
             </div>
             <div class="filter-category">
-                <button class="btn open-filter" data-target="#filterStates" aria-expanded="true" aria-controls="filter-states">States</button>
+                <button class="btn open-filter" data-target="#filterStates" aria-expanded="true" aria-controls="filter-states">{% trans 'States' %}</button>
                 <div class="category-options-list" id="filterStates">
                     {% for state in states %}
-                    <button class="btn category-option {% if state.state in states_to_filter_by %}active{% endif %}" data-param="state" data-value="{{ state.state|urlencode }}">{{ state.state|capfirst }}</button>
+                    <button class="btn category-option {% if state.state in states_to_filter_by %}active{% endif %}" data-param="state" data-value="{{ state.state|urlencode }}">{{ state.state }}</button>
                     {% endfor %}
                 </div>
             </div>
             <div class="filter-category">
-                <button class="btn open-filter" data-target="#filterLanguages" aria-expanded="true" aria-controls="filter-languages">Languages</button>
+                <button class="btn open-filter" data-target="#filterLanguages" aria-expanded="true" aria-controls="filter-languages">{% trans 'Languages' %}</button>
                 <div class="category-options-list" id="filterLanguages">
                     {% for language in languages %}
                     <button class="btn category-option {% if language.language in languages_to_filter_by %}active{% endif %}" data-param="language" data-value="{{ language.language|urlencode }}">{{ language.language|to_language_name }}</button>
@@ -61,7 +62,7 @@
                 </div>
             </div>
             <div class="filter-category">
-                <button class="btn open-filter" data-target="#filterCurriculum" aria-expanded="true" aria-controls="filter-curriculum">Curriculum Followed</button>
+                <button class="btn open-filter" data-target="#filterCurriculum" aria-expanded="true" aria-controls="filter-curriculum">{% trans 'Curriculum Followed' %}</button>
                 <div class="category-options-list" id="filterCurriculum">
                     {% for curriculum in curriculums %}
                     <button class="btn category-option {% if curriculum.curriculum_followed in curriculums_to_filter_by %}active{% endif %}" data-param="curriculum" data-value="{{ curriculum.curriculum_followed|urlencode }}">{{ curriculum.curriculum_followed|capfirst }}</button>
@@ -96,8 +97,8 @@
                     <i class="fas fa-chevron-down"></i>
                 </button>
                 <div class="dropdown-menu" aria-labelledby="sortOptionSelector">
-                    <span class="dropdown-item sort-by-option" data-sort="newest">Newest</span>
-                    <span class="dropdown-item sort-by-option" data-sort="oldest">Oldest</span>
+                    <span class="dropdown-item sort-by-option" data-sort="newest">{% trans 'Newest' %}</span>
+                    <span class="dropdown-item sort-by-option" data-sort="oldest">{% trans 'Oldest' %}</span>
                 </div>
             </div>
         </div>
@@ -105,8 +106,8 @@
             {% for result in results %}
             <li class="search-result-item">
                 <div class="search-result-item-header">
-                    <p class="item-number">#{{ result.id }} | Question</p>
-                    <button class="btn bookmark-button {% if result.id in bookmarks %}bookmarked{% endif %}" data-content="question" data-id="{{ result.id }}">{% if result.id in bookmarks %}<i class="fas fa-bookmark"></i> Bookmarked{% else %}<i class="far fa-bookmark"></i> Bookmark{% endif %}</button>
+                    <p class="item-number">#{{ result.id }} | {% trans 'Question' %}</p>
+                    <button class="btn bookmark-button {% if result.id in bookmarks %}bookmarked{% endif %}" data-content="question" data-id="{{ result.id }}">{% if result.id in bookmarks %}<i class="fas fa-bookmark"></i> {% trans 'Bookmarked' %}{% else %}<i class="far fa-bookmark"></i> {% comment %}Translators: this is a verb ("Bookmark this item"){% endcomment %}{% trans 'Bookmark' %}{% endif %}</button>
                 </div>
                 <h3 class="item-title">
                     {{ result.question_text }}
@@ -171,14 +172,14 @@
                         {% endif %}
                     </div>
                     {% endif %}
-                    {% if page_title == 'Answer Questions' %}
+                    {% if page_title == _('Answer Questions') %}
                         <div class="item-context-controls">
                             {% if page_title == 'Answer Questions' %}
                             <a href="{% url 'dashboard:submit-answer' question_id=result.id %}" class="btn btn-small btn-primary">Answer</a>
                             {% endif %}
                         </div>
                     {% endif %}
-                    {% if page_title == 'View Questions' or page_title == 'Search' %}
+                    {% if page_title == _('View Questions') or page_title == _('Search') %}
                         {% for answer in result.answers.all %}
                         {% if answer.approved_by %}
                             <div class="item-context-controls">
@@ -188,29 +189,29 @@
                         {% endfor %}
                     {% endif %}
                 </div>
-                {% if page_title == 'Review Answers' %}
+                {% if page_title == _('Review Answers') %}
                     {% for answer in result.answers.all %}
                     <div class="answer-preview">
                         <!-- <h4>Answered by <b>{{ answer.answered_by.get_full_name }}</b></h4> -->
                         <p>{{ answer.answer_text|striptags|truncatechars:200 }}</p>
                         {% for credit in answer.credits.all %}
                             <h4>
-                                {{ credit.credit_user_name }} ({{ credit.credit_title|capfirst }})
+                                {{ credit.credit_user_name }} ({% trans credit.credit_title %})
                             </h4>
                         {% endfor %}
                         <div class="review-answer-controls">
-                            <a href="{% url 'dashboard:review-answer' question_id=result.id answer_id=answer.id %}" class="btn btn-small btn-primary">Review</a>
+                            <a href="{% url 'dashboard:review-answer' question_id=result.id answer_id=answer.id %}" class="btn btn-small btn-primary">{% trans 'Review' %}</a>
                         </div>
                     </div>
                     {% endfor %}
                 {% endif %}
-                {% if page_title == 'Translate Answers' %}
+                {% if page_title == _('Translate Answers') %}
                     {% for answer in result.answers.all %}
                     <div class="answer-preview">
                         <h4>Answered by <b>{{ answer.submitted_by.get_full_name }}</b></h4>
                         <p>{{ answer.answer_text|striptags|truncatechars:200 }}</p>
                         <div class="review-answer-controls">
-                            <a href="{% url 'dashboard:translate-answer' source=result.id answer=answer.id %}" class="btn btn-small btn-primary">Translate</a>
+                            <a href="{% url 'dashboard:translate-answer' source=result.id answer=answer.id %}" class="btn btn-small btn-primary">{% trans 'Translate' %}</a>
                         </div>
                     </div>
                     {% endfor %}
@@ -233,7 +234,7 @@
         {% else %}
         <div class="no-search-results-container">
             <i class="far fa-frown"></i>
-            <p>No results found. Try changing the filters or search for something else</p>
+            <p>{% blocktrans %}No results found. Try changing the filters or search for something else{% endblocktrans %}</p>
         </div>
         {% endif %}
     </div>

--- a/public_website/templates/public_website/user-profile.html
+++ b/public_website/templates/public_website/user-profile.html
@@ -2,6 +2,7 @@
 
 {% block title %} {{ page_title }} | Sawaliram {% endblock %}
 
+{% load i18n %}
 {% load static %}
 {% load to_language_name %}
 
@@ -12,7 +13,7 @@
         {% for message in messages %}
         <div class="alert alert-dismissible fade show {% if message.tags %} {{ message.tags }} {% endif %}" role="alert">
             {{ message }}
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <button type="button" class="close" data-dismiss="alert" aria-label="{% trans 'Close' %}">
                 <span aria-hidden="true">&times;</span>
             </button>
         </div>
@@ -20,10 +21,14 @@
     {% endif %}
 
     <div class="profile-header">
-        <img src="{% static 'user/default.png' %}" alt="Profile Picture">
+        <img src="{% static 'user/default.png' %}" alt="{% trans 'Profile Picture' %}">
         <h1 class="user-name">{{ selected_user.get_full_name }}</h1>
         {% if selected_user.organisation %}
-            <p class="organisation">{% if selected_user.organisation_role %}{{ selected_user.organisation_role }} at {% endif %}{{ selected_user.organisation }}</p>
+            <p class="organisation">
+              {% if selected_user.organisation_role %}{% blocktrans %}{{ selected_user.organisation_role }} at {{ selected_user.organisation }}{% endblocktrans %}
+              {% else %}{{ selected_user.organisation }}
+              {% endif %}
+            </p>
         {% endif %}
     </div>
     
@@ -31,29 +36,29 @@
         <div class="nav nav-pills user-profile-nav" role="tablist">
             {% if request.user.id == selected_user.id %}
             <a class="nav-item nav-link active" data-toggle="tab" href="#settings" role="tab" aria-controls="settings" aria-selected="true">
-                <img class="slow-transition" src="{% static 'icons/menu_settings.png' %}" alt="User Settings">
-                Settings
+                <img class="slow-transition" src="{% static 'icons/menu_settings.png' %}" alt="{% trans 'User Settings'%}">
+                {% trans 'Settings' %}
             </a>
             <a class="nav-item nav-link" data-toggle="tab" href="#drafts" role="tab" aria-controls="drafts" aria-selected="true">
-                <img class="slow-transition" src="{% static 'icons/menu_drafts.png' %}" alt="User Drafts">
-                Drafts
+                <img class="slow-transition" src="{% static 'icons/menu_drafts.png' %}" alt="{% trans 'User Drafts' %}">
+                {% trans 'Drafts' %}
             </a>
             <a class="nav-item nav-link" data-toggle="tab" href="#notifications" role="tab" aria-controls="notifications" aria-selected="true">
-                <img class="slow-transition" src="{% static 'icons/menu_notifications.png' %}" alt="User Notifications">
-                Notifications
+                <img class="slow-transition" src="{% static 'icons/menu_notifications.png' %}" alt="{% trans 'User Notifications' %}">
+                {% trans 'Notifications' %}
                 {% if request.user.notifications.all|length > 0 %}
                     <span class="notification-dot">{{ request.user.notifications.all|length }}</span>
                 {% endif %}
             </a>
             {% endif %}
             <a class="nav-item nav-link {% if request.user.id != selected_user.id %}active{% endif%}" data-toggle="tab" href="#submissions" role="tab" aria-controls="submissions" aria-selected="true">
-                <img class="slow-transition" src="{% static 'icons/menu_submissions.png' %}" alt="User Submissions">
-                Submissions
+                <img class="slow-transition" src="{% static 'icons/menu_submissions.png' %}" alt="{% trans 'User Submissions' %}">
+                {% trans 'Submissions' %}
             </a>
             {% if request.user.id == selected_user.id %}
             <a class="nav-item nav-link" data-toggle="tab" href="#bookmarks" role="tab" aria-controls="bookmarks" aria-selected="true">
-                <img class="slow-transition" src="{% static 'icons/menu_bookmarks.png' %}" alt="User Bookmarks">
-                Bookmarks
+                <img class="slow-transition" src="{% static 'icons/menu_bookmarks.png' %}" alt="{% trans 'User Bookmarks' %}">
+                {% trans 'Bookmarks' %}
             </a>
             {% endif %}
         </div>
@@ -63,24 +68,24 @@
         {% if request.user.id == selected_user.id %}
         <div class="tab-pane fade show active" id="settings" role="tabpanel" aria-labelledby="settings">
             <div class="tab-section">
-                <h3 class="tab-subheading">Organisation</h3>
-                <p class="tab-section-intro">Details of your organisation and your role</p>
+                <h3 class="tab-subheading">{% trans 'Organisation' %}</h3>
+                <p class="tab-section-intro">{% trans 'Details of your organisation and your role' %}</p>
                 <form action="" method="POST">
                     {% csrf_token %}
-                    <input type="text" maxlength="50" name="organisation-role" placeholder="Your role" {% if request.user.organisation_role %}value="{{ request.user.organisation_role }}"{% endif %}>
-                    <input type="text" maxlength="200" name="organisation-name" placeholder="Organisation name" {% if request.user.organisation %}value="{{ request.user.organisation }}"{% endif %}>
-                    <button class="btn btn-secondary sub-task-button">Update organisation info</button>
+                    <input type="text" maxlength="50" name="organisation-role" placeholder="{% trans 'Your role' %}" {% if request.user.organisation_role %}value="{{ request.user.organisation_role }}"{% endif %}>
+                    <input type="text" maxlength="200" name="organisation-name" placeholder="{% trans 'Organisation name' %}" {% if request.user.organisation %}value="{{ request.user.organisation }}"{% endif %}>
+                    <button class="btn btn-secondary sub-task-button">{% trans 'Update organisation info' %}</button>
                 </form>
             </div>
             <div class="tab-section">
-                <h3 class="tab-subheading">Security</h3>
-                <p class="tab-section-intro">Manage your password</p>
+                <h3 class="tab-subheading">{% trans 'Security' %}</h3>
+                <p class="tab-section-intro">{% trans 'Manage your password' %}</p>
                 <form action="" method="POST">
                     {% csrf_token %}
-                    <input type="password" name="current-password" placeholder="Current password" required>
-                    <input type="password" name="new-password" placeholder="New password" required>
-                    <input type="password" name="confirm-new-password" placeholder="Confirm new password" required>
-                    <button class="btn btn-secondary sub-task-button">Update password</button>
+                    <input type="password" name="current-password" placeholder="{% trans 'Current password' %}" required>
+                    <input type="password" name="new-password" placeholder="{% trans 'New password' %}" required>
+                    <input type="password" name="confirm-new-password" placeholder="{% trans 'Confirm new password' %}" required>
+                    <button class="btn btn-secondary sub-task-button">{% trans 'Update password' %}</button>
                 </form>
             </div>
         </div>
@@ -88,8 +93,8 @@
             {% if answer_drafts or article_drafts or answer_translation_drafts or article_translation_drafts %}
                 {% if answer_drafts %}
                 <div class="tab-section">
-                    <h3 class="tab-subheading">Answers</h3>
-                    <p class="tab-section-intro">Your draft answers</p>
+                    <h3 class="tab-subheading">{% trans 'Answers' %}</h3>
+                    <p class="tab-section-intro">{% trans 'Your draft answers' %}</p>
                     <ul class="card-list">
                         {% for draft in answer_drafts %}
                         <li>
@@ -97,11 +102,11 @@
                             <p class="tab-section-intro">
                                 {{ draft.answer_text|striptags|truncatechars:140  }}
                             </p>
-                            <a href="{% url 'dashboard:submit-answer' question_id=draft.question_id.id %}" class="btn btn-secondary sub-task-button">Continue writing</a>
+                            <a href="{% url 'dashboard:submit-answer' question_id=draft.question_id.id %}" class="btn btn-secondary sub-task-button">{% trans 'Continue writing' %}</a>
                             <form class="inline-block" action="{% url 'sawaliram_auth:remove-draft' %}" method="POST">
                                 {% csrf_token %}
                                 <input type="hidden" name="draft-id" value="{{ draft.id }}">
-                                <button class="btn btn-secondary-hollow sub-task-button delete" type="submit"><i class="far fa-trash-alt"></i> Delete</button>
+                                <button class="btn btn-secondary-hollow sub-task-button delete" type="submit"><i class="far fa-trash-alt"></i> {% trans 'Delete' %}</button>
                             </form>
                         </li>
                         {% endfor %}
@@ -110,19 +115,19 @@
                 {% endif %}
                 {% if article_drafts %}
                 <div class="tab-section">
-                    <h3 class="tab-subheading">Articles</h3>
-                    <p class="tab-section-intro">Your draft articles</p>
+                    <h3 class="tab-subheading">{% trans 'Articles' %}</h3>
+                    <p class="tab-section-intro">{% trans 'Your draft articles' %}</p>
                     <ul class="card-list">
                         {% for draft in article_drafts %}
                         <li>
-                            <h4>{{ draft.title|default:"(untitled)" }}</h4>
+                            <h4>{{ draft.title|default:_("(untitled)") }}</h4>
                             <p class="tab-section-intro">
                                 {{ draft.body|striptags|truncatechars:140  }}
                             </p>
-                            <a href="{% url 'dashboard:edit-article' draft_id=draft.id %}" class="btn btn-secondary sub-task-button">Continue writing</a>
+                            <a href="{% url 'dashboard:edit-article' draft_id=draft.id %}" class="btn btn-secondary sub-task-button">{% trans 'Continue writing' %}</a>
                             <form class="inline-block" action="{% url 'dashboard:delete-article' draft.id %}" method="GET">
                                 {% csrf_token %}
-                                <button class="btn btn-secondary-hollow sub-task-button delete" type="submit"><i class="far fa-trash-alt"></i> Delete</button>
+                                <button class="btn btn-secondary-hollow sub-task-button delete" type="submit"><i class="far fa-trash-alt"></i> {% trans 'Delete' %}</button>
                             </form>
                         </li>
                         {% endfor %}
@@ -130,19 +135,17 @@
                 </div>
                 {% endif %}
                 {% if article_translation_drafts or answer_translation_drafts %}
-                <h3 class="tab-subheading">Translations</h3>
+                <h3 class="tab-subheading">{% trans 'Translations' %}</h3>
                 <p class="tab-section-intro">
-                  Your draft
-                  {% if article_translation_drafts %} article{% endif %}
-                  {% if answer_translation_drafts and article_translation_drafts %} and{% endif %}
-                  {% if answer_translation_drafts %} answer{% endif %}
-                  translations
-                </p>
+                  {% if article_translation_drafts and answer_translation_drafts %}{% trans 'Your draft article and answer translations' %}
+                  {% elif article_translation_drafts %}{% trans 'Your draft article translations' %}
+                  {% elif answer_translation_drafts %}{% trans 'Your draft answer translations' %}
+                  {% endif %}                </p>
                 <ul class="card-list">
                   {% for draft in article_translation_drafts %}
                   <li>
                       <h4>
-                        {{ draft.title|default:"(untitled)" }}
+                        {{ draft.title|default:_("(untitled)") }}
                         <small>({{ draft.source.language|to_language_name }} -> {{ draft.language|to_language_name }})</small>
                         </h4>
                       <p class="tab-section-intro">
@@ -151,10 +154,10 @@
                       <p class="tab-section-intro">
                         <small>Translated from <a href="{{ draft.source.get_absolute_url }}">{{ draft.source.title }}</a></small>
                       </p>
-                      <a href="{% url 'dashboard:edit-article-translation' source=draft.source.id lang_from=draft.source.language lang_to=draft.language %}" class="btn btn-secondary sub-task-button">Continue translating</a>
+                      <a href="{% url 'dashboard:edit-article-translation' source=draft.source.id lang_from=draft.source.language lang_to=draft.language %}" class="btn btn-secondary sub-task-button">{% trans 'Continue translating' %}</a>
                       <form class="inline-block" action="{% url 'dashboard:delete-article-translation' draft.id %}" method="GET">
                           {% csrf_token %}
-                          <button class="btn btn-secondary-hollow sub-task-button delete" type="submit"><i class="far fa-trash-alt"></i> Delete</button>
+                          <button class="btn btn-secondary-hollow sub-task-button delete" type="submit"><i class="far fa-trash-alt"></i> {% trans 'Delete' %}</button>
                       </form>
                   </li>
                   {% endfor %}
@@ -167,10 +170,10 @@
                       <p class="tab-section-intro">
                           {{ draft.body|default:""|striptags|truncatechars:140  }}
                       </p>
-                      <a href="{% url 'dashboard:edit-answer-translation' answer=draft.source.id source=draft.source.question_id.id lang_from=draft.source.language lang_to=draft.language %}" class="btn btn-secondary sub-task-button">Continue translating</a>
+                      <a href="{% url 'dashboard:edit-answer-translation' answer=draft.source.id source=draft.source.question_id.id lang_from=draft.source.language lang_to=draft.language %}" class="btn btn-secondary sub-task-button">{% trans 'Continue translating' %}</a>
                       <form class="inline-block" action="{% url 'dashboard:delete-answer-translation' draft.id %}" method="GET">
                           {% csrf_token %}
-                          <button class="btn btn-secondary-hollow sub-task-button delete" type="submit"><i class="far fa-trash-alt"></i> Delete</button>
+                          <button class="btn btn-secondary-hollow sub-task-button delete" type="submit"><i class="far fa-trash-alt"></i> {% trans 'Delete' %}</button>
                       </form>
                   </li>
                   {% endfor %}
@@ -178,7 +181,7 @@
                 {% endif %}
             {% else %}
             <div class="empty-tab">
-                <h3><i class="far fa-meh"></i> No drafts</h3>
+                <h3><i class="far fa-meh"></i> {% trans 'No drafts' %}</h3>
             </div>
             {% endif %}
         </div>
@@ -215,7 +218,7 @@
             </div>
             {% else %}
             <div class="empty-tab">
-                <h3><i class="far fa-meh"></i> No notifications</h3>
+                <h3><i class="far fa-meh"></i> {% trans 'No notifications' %}</h3>
             </div>
             {% endif %}
         </div>
@@ -224,20 +227,24 @@
             {% if submitted_questions or submitted_answers or submitted_articles or published_articles or article_translation_submissions or answer_translation_submissions %}
                 {% if submitted_questions %}
                 <div class="tab-section">
-                    <h3 class="tab-subheading">Questions</h3>
-                    <p class="tab-section-intro">Questions submitted by {% if request.user.id != selected_user.id %} {{ selected_user.first_name }}{% else %}you{% endif%}</p>
+                    <h3 class="tab-subheading">{% trans 'Questions' %}</h3>
+                    <p class="tab-section-intro">
+                      {% if request.user.id != selected_user.id %}{% blocktrans %}Questions submitted by {{ selected_user.first_name }}{% endblocktrans %}
+                      {% else %}{% blocktrans %}Questions submitted by you{% endblocktrans %}
+                      {% endif%}
+                    </p>
                     <ul class="card-list">
                         {% for question in submitted_questions %}
                         <li>
                             <h4>{{ question.question_count }} questions</h4>
-                            <p class="tab-section-intro">Submitted on {{ question.created_on|date:"jS F, Y" }}</p>
+                            <p class="tab-section-intro">{% blocktrans %}Submitted on {{ question.created_on|date:"jS F, Y" }}{% endblocktrans %}</p>
                             {% if question.status == 'new' %}
                             <p class="tab-section-status pending">
-                                Review Pending
+                                {% trans 'Review Pending' %}
                             </p>
                             {% elif question.status == 'curated' %}
                             <p class="tab-section-status success">
-                                Ready to answer
+                                {% trans 'Ready to answer' %}
                             </p> 
                             {% endif %}
                         </li>
@@ -247,8 +254,12 @@
                 {% endif %}
                 {% if submitted_answers %}
                 <div class="tab-section">
-                    <h3 class="tab-subheading">Answers</h3>
-                    <p class="tab-section-intro">Answers submitted by {% if request.user.id != selected_user.id %} {{ selected_user.first_name }}{% else %}you{% endif%}</p>
+                    <h3 class="tab-subheading">{% trans 'Answers' %}</h3>
+                    <p class="tab-section-intro">
+                      {% if request.user.id != selected_user.id %}{% blocktrans %}Answers submitted by {{ selected_user.first_name }}{% endblocktrans %}
+                      {% else %}{% blocktrans %}Answers submitted by you{% endblocktrans %}
+                      {% endif%}
+                    </p>
                     <ul class="card-list">
                         {% for answer in submitted_answers %}
                         <li>
@@ -259,7 +270,7 @@
                                     {{ answer.answer_text|striptags|truncatechars:140 }}
                                 </p>
                                 <p class="tab-section-status pending">
-                                    Review Pending
+                                    {% trans 'Review Pending' %}
                                 </p>
                         </li>
                         {% endfor %}
@@ -268,8 +279,10 @@
                 {% endif %}
                 {% if submitted_articles  or published_articles%}
                 <div class="tab-section">
-                    <h3 class="tab-subheading">Articles</h3>
-                    <p class="tab-section-intro">Articles submitted by {% if request.user.id != selected_user.id %} {{ selected_user.first_name }}{% else %}you{% endif%}</p>
+                    <h3 class="tab-subheading">{% trans 'Articles' %}</h3>
+                      {% if request.user.id != selected_user.id %}{% blocktrans %}Articles submitted by {{ selected_user.first_name }}{% endblocktrans %}
+                      {% else %}{% blocktrans %}Articles submitted by you{% endblocktrans %}
+                      {% endif%}
                     <ul class="card-list">
                         {% for article in submitted_articles %}
                         <li>
@@ -280,7 +293,7 @@
                                     {{ article.body|striptags|truncatechars:140 }}
                                 </p>
                                 <p class="tab-section-status pending">
-                                    Review Pending
+                                    {% trans 'Review Pending' %}
                                 </p>
                         </li>
                         {% endfor %}
@@ -293,7 +306,7 @@
                                     {{ article.body|striptags|truncatechars:140 }}
                                 </p>
                                 <p class="tab-section-status success">
-                                    Published
+                                    {% trans 'Published' %}
                                 </p>
                         </li>
                         {% endfor %}
@@ -304,20 +317,19 @@
 
               {% if article_translation_submissions or answer_translation_submissions %}
               <div class="tab-section">
-                <h3 class="tab-subheading">Translations</h3>
+                <h3 class="tab-subheading">{% trans 'Translations' %}</h3>
                 <p class="tab-section-intro">
-                  Your submitted
-                  {% if article_translation_submissions %} article{% endif %}
-                  {% if answer_translation_submissions and article_translation_submissions %} and{% endif %}
-                  {% if answer_translation_submissions %} answer{% endif %}
-                  translations
+                  {% if article_translation_submissions and answer_translation_submissions %}{% trans 'Your submitted article and answer translations' %}
+                  {% elif article_translation_submissions %}{% trans 'Your submitted article translations' %}
+                  {% elif answer_translation_submissions %}{% trans 'Your submitted answer translations' %}
+                  {% endif %} 
                 </p>
                 <ul class="card-list">
                   {% for submission in article_translation_submissions %}
                   <li>
                       <a class="task-link" href="{{ submission.get_absolute_url }}">
                         <h4>
-                          {{ submission.title|default:"(untitled)" }}
+                          {{ submission.title|default:_("(untitled)") }}
                           <small>({{ submission.source.language }} -> {{ submission.language }})</small>
                         </h4>
                       </a>
@@ -325,10 +337,10 @@
                           {{ submission.body|default:""|striptags|truncatechars:140  }}
                       </p>
                       <p class="tab-section-intro">
-                        <small>Translated from <a href="{{ submission.source.get_absolute_url }}">{{ submission.source.title }}</a></small>
+                        <small>{% trans 'Translated from' %} <a href="{{ submission.source.get_absolute_url }}">{{ submission.source.title }}</a></small>
                       </p>
                       <p class="tab-section-status pending">
-                          Review Pending
+                          {% trans 'Review Pending' %}
                       </p>
                   </li>
                   {% endfor %}
@@ -344,7 +356,7 @@
                           {{ submission.answer_text|default:""|striptags|truncatechars:140  }}
                       </p>
                       <p class="tab-section-status pending">
-                          Review Pending
+                          {% trans 'Review Pending' %}
                       </p>
                   </li>
                   {% endfor %}
@@ -355,7 +367,7 @@
 
             {% else %}
                 <div class="empty-tab">
-                    <h3><i class="far fa-meh"></i> No submissions</h3>
+                    <h3><i class="far fa-meh"></i> {% trans 'No submissions' %}</h3>
                 </div>
             {% endif %}
         </div>
@@ -363,15 +375,15 @@
         <div class="tab-pane fade" id="bookmarks" role="tabpanel" aria-labelledby="bookmarks">
             {% if bookmarked_questions %}
             <div class="tab-section">
-                <h3 class="tab-subheading">Questions</h3>
-                <p class="tab-section-intro">Questions you saved</p>
+                <h3 class="tab-subheading">{% trans 'Questions' %}</h3>
+                <p class="tab-section-intro">{% trans 'Questions you saved' %}</p>
                 <ul class="card-list">
                     {% for bookmark in bookmarked_questions %}
                     <li>
                         <h4>{{ bookmark.question }}</h4>
                         <div>
                             <p class="tab-section-status pending">
-                                Not Answered
+                                {% trans 'Not Answered' %}
                             </p>
                         </div>
                         <br>
@@ -379,7 +391,7 @@
                             {% csrf_token %}
                             <input type="hidden" name="content-type" value="question">
                             <input type="hidden" name="question-id" value="{{ bookmark.question.id }}">
-                            <button class="btn btn-secondary-hollow sub-task-button delete" type="submit"><i class="far fa-trash-alt"></i> Delete</button>
+                            <button class="btn btn-secondary-hollow sub-task-button delete" type="submit"><i class="far fa-trash-alt"></i> {% trans 'Delete' %}</button>
                         </form>
                     </li>
                     {% endfor %}
@@ -387,7 +399,7 @@
             </div>
             {% else %}
                 <div class="empty-tab">
-                    <h3><i class="far fa-meh"></i> No bookmarks</h3>
+                    <h3><i class="far fa-meh"></i> {% trans 'No bookmarks' %}</h3>
                 </div>
             {% endif %}
         </div>

--- a/public_website/templates/public_website/view-answer.html
+++ b/public_website/templates/public_website/view-answer.html
@@ -1,10 +1,11 @@
 {% extends "public_website/base.html" %}
 
-{% block title %} View Answer | Sawaliram {% endblock %}
-
+{% load i18n %}
 {% load static %}
 {% load render_linebreaks %}
 {% load to_language_name %}
+
+{% block title %} {% trans 'View Answer' %} | {% trans 'Sawaliram' %}{% endblock %}
 
 {% block content %}
 
@@ -58,7 +59,7 @@
             <span class="highlighted-meta">
                 <i class="fas fa-user-graduate"></i>
                 <span class="meta-value">
-                    Class {{ question.student_class }}
+                    {% trans 'Class' %} {{ question.student_class }}
                 </span>
             </span>
             {% endif %}
@@ -75,7 +76,7 @@
         {% if answer.translations %}
         <div class="dropdown">
           <button class="btn btn-secondary btn-small dropdown-toggle" type="button" id="translationSelectorButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Read answer in: {{ answer.tr_language|to_language_name }}
+            {% trans 'Read answer in:' %} {{ answer.tr_language|to_language_name }}
           </button>
           <div class="dropdown-menu" aria-labelledby="translationSelectorButton">
             {% for lang, language in answer.list_available_languages %}
@@ -95,11 +96,11 @@
 {% if user.is_authenticated %}
 <div class="answer-comment-related-section">
     <div class="comments">
-        <h2>Comments</h2>
+        <h2>{% trans 'Comments' %}</h2>
         <form action="{% url 'public_website:submit-user-comment-answer' question.id answer.id %}" method="POST">
             {% csrf_token %}
             <textarea name="comment-text" rows="4" placeholder="Join the conversation"></textarea>
-            <button type="submit" class="btn btn-secondary">Add Comment</button>
+            <button type="submit" class="btn btn-secondary">{% trans 'Add Comment' %}</button>
         </form>
         {% if comments %}
             <ul class="comment-list">
@@ -109,12 +110,12 @@
                         <h3>{{ comment.author.get_full_name }}</h3>
                         {% if comment.author == request.user %}
                         <div class="delete-comment-wrapper">
-                            <button type="submit" class="btn delete-comment slow-transition">Delete <i class="far fa-trash-alt"></i></button>
+                            <button type="submit" class="btn delete-comment slow-transition">{% trans 'Delete' %} <i class="far fa-trash-alt"></i></button>
                             <form action="{% url 'public_website:delete-user-comment-answer' question.id answer.id comment.id %}" class="delete-comment-form slow-transition" method="POST">
                                 {% csrf_token %}
-                                <span>Are you sure?</span>
-                                <button class="btn confirm-delete delete-yes">Yes</button> /
-                                <button class="btn confirm-delete delete-no">No</button>
+                                <span>{% trans 'Are you sure?' %}</span>
+                                <button class="btn confirm-delete delete-yes">{% trans 'Yes' %}</button> /
+                                <button class="btn confirm-delete delete-no">{% trans 'No' %}</button>
                             </form>
                         </div>
                         {% endif %}

--- a/public_website/views.py
+++ b/public_website/views.py
@@ -226,7 +226,7 @@ class SearchView(View):
 
         # save list of IDs for Submit Answer/Review Answer
         page_title = self.get_page_title(request)
-        if page_title == 'Review Answers' or page_title == 'Answer Questions':
+        if page_title == _('Review Answers') or page_title == _('Answer Questions'):
             result_id_list = [id['id'] for id in result.values('id')]
             request.session['result_id_list'] = result_id_list
 
@@ -263,7 +263,7 @@ class SearchView(View):
         }
 
         # create list of active categories
-        if page_title == 'Search':
+        if page_title == _('Search'):
             active_categories = request.GET.getlist('category')
             context['active_categories'] = active_categories
         return render(request, self.get_template(request), context)
@@ -284,7 +284,7 @@ class ViewAnswer(View):
 
         context = {
             'dashboard': 'False',
-            'page_title': 'View Answer',
+            'page_title': _('View Answer'),
             'question': question,
             'answer': answer,
             'comments': answer.user_comments.all(),
@@ -300,7 +300,7 @@ class ArticleView(View):
 
         # Don't allow other people to see an unpublished draft
         if article.is_draft and article.author != request.user:
-            raise Http404('Article does not exist')
+            raise Http404(_('Article does not exist'))
 
         # If it's under review, redirect to the review page
         if article.is_submitted:
@@ -341,7 +341,7 @@ class SubmitUserCommentOnAnswer(View):
         try:
             answer = Answer.objects.get(pk=answer_id)
         except Answer.DoesNotExist:
-            raise Http404('Answer does not exist')
+            raise Http404(_('Answer does not exist'))
 
         comment = AnswerUserComment()
         comment.text = request.POST['comment-text']
@@ -359,7 +359,9 @@ class SubmitUserCommentOnAnswer(View):
 
             comment_notification = Notification(
                 notification_type='comment',
-                title_text=str(request.user.get_full_name()) + ' left a comment on your answer',
+                title_text=_('%(name)s left a comment on your answer') % {
+                    'name': str(request.user.get_full_name()),
+                },
                 description_text="On your answer for the question '" + question_text + "'",
                 target_url=reverse('public_website:view-answer', kwargs={'question_id': question_id, 'answer_id': answer_id}),
                 user=answer.answered_by
@@ -382,12 +384,12 @@ class DeleteUserCommentOnAnswer(View):
         try:
             answer = Answer.objects.get(pk=answer_id)
         except Answer.DoesNotexist:
-            raise Http404('Answer does not exist')
+            raise Http404(_('Answer does not exist'))
 
         try:
             comment = answer.user_comments.get(pk=comment_id)
         except AnswerUserComment.DoesNotExist:
-            raise Http404('No matching comment')
+            raise Http404(_('No matching comment'))
 
         return comment
 
@@ -411,7 +413,7 @@ class DeleteUserCommentOnAnswer(View):
         comment = self.fetch_comment(question_id, answer_id, comment_id)
 
         if request.user != comment.author:
-            raise PermissionDenied('You are not authorised to delete that comment.')
+            raise PermissionDenied(_('You are not authorised to delete that comment.'))
 
         comment.delete()
 
@@ -444,7 +446,10 @@ class UserProfileView(View):
             notifications = Notification.objects.filter(user=user_id)
             context = {
                 'dashboard': 'False',
-                'page_title': selected_user.first_name + "'s Profile",
+                # Translators: This is the title for the User Profile page
+                'page_title': _("%(name)s's Profile") % {
+                    'name': selected_user.first_name,
+                },
                 'enable_breadcrumbs': 'Yes',
                 'selected_user': selected_user,
                 'answer_drafts': answer_drafts,
@@ -471,23 +476,23 @@ class UserProfileView(View):
             if request.POST.get('organisation-role'):
                 user.organisation_role = request.POST.get('organisation-role')
                 user.save()
-            messages.success(request, ('Your organisation details have been updated!'))
+            messages.success(request, (_('Your organisation details have been updated!')))
         elif request.POST.get('current-password'):
             match_check_old = check_password(request.POST.get('current-password'), request.user.password)
             if match_check_old:
                 if request.POST.get('new-password') == request.POST.get('confirm-new-password'):
                     match_check_new = check_password(request.POST.get('new-password'), request.user.password)
                     if match_check_new:
-                        messages.error(request, ('New password cannot be same as the current password'))
+                        messages.error(request, (_('New password cannot be same as the current password')))
                     else:
                         user.password = make_password(password=request.POST.get('new-password'))
                         user.save()
                         login(request, user)
-                        messages.success(request, ('Your password has been updated!'))
+                        messages.success(request, (_('Your password has been updated!')))
                 else:
-                    messages.error(request, ('Make sure you entered the new password correctly both times'))
+                    messages.error(request, _('Make sure you entered the new password correctly both times'))
             else:
-                messages.error(request, ('The password you entered is incorrect'))
+                messages.error(request, _('The password you entered is incorrect'))
 
         return redirect('public_website:user-profile', user_id=request.user.id)
 
@@ -506,7 +511,7 @@ class ViewNotification(View):
 class GetInvolvedView(View):
     def get(self, request):
         context = {
-            'page_title': 'Get Involved',
+            'page_title': _('Get Involved'),
         }
         return render(request, 'public_website/get-involved.html', context)
 
@@ -514,19 +519,19 @@ class GetInvolvedView(View):
 class About(View):
     def get(self, request):
         context = {
-            'page_title': 'About',
+            'page_title': _('About'),
         }
         return render(request, 'public_website/about.html', context)
 class ResearchPage(View):
     def get(self, request):
         context = {
-            'page_title': 'Research'
+            'page_title': _('Research')
         }
         return render(request, 'public_website/research.html', context)
 
 class FAQPage(View):
     def get(self, request):
         context = {
-            'page_title': 'Frequently Asked Questions'
+            'page_title': _('Frequently Asked Questions')
         }
         return render(request, 'public_website/faq.html', context)


### PR DESCRIPTION
Most of the strings in the public website's pages have been marked as translatable. You can now generate the translations file using `./manage.py makemessages --locale LOCALE_NAME`, for example `./manage.py makemessages --locale hi`.

The resulting `.po` file (`locale/LOCALE_NAME/LC_MESSAGES/django.po`) can be translated manually or using a tool like [Gtranslator](https://wiki.gnome.org/Apps/Gtranslator).

Once translated, compile the `.po` files to machine-readable `.mo` by running `./manage.py compilemessages`. Translations should then work on the public-facing website as expected.