### PR TITLE
Tweak migration dashboard.0016 to make compatible after merge

### DIFF
--- a/dashboard/migrations/0016_make_question_fields_optional.py
+++ b/dashboard/migrations/0016_make_question_fields_optional.py
@@ -82,7 +82,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterField(
             model_name='question',
-            name='question_language',
+            name='language',
             field=models.CharField(blank=True, max_length=100),
         ),
         migrations.AlterField(
@@ -192,7 +192,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterField(
             model_name='questionarchive',
-            name='question_language',
+            name='language',
             field=models.CharField(blank=True, max_length=100),
         ),
         migrations.AlterField(


### PR DESCRIPTION
The old migration was assuming a field called `question_language`, but that field was renamed to `question` in another migration. This applies to both the `Question` and `QuestionArchive` models.