### PR TITLE
Notify authors and reviewers when a translation is published

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -11,6 +11,7 @@ from django.shortcuts import (
 )
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import csrf_exempt
+from django.utils.translation import get_language_info
 from django.utils.decorators import method_decorator
 from django.db.models import Subquery, Q
 from django.views import View
@@ -1216,7 +1217,7 @@ class TranslateAnswersList(SearchView):
                     Q(state__icontains=request.GET.get('q')) |
                     Q(field_of_interest__icontains=request.GET.get('q'))
             )
-            
+
             results['articles'] = (PublishedArticle.objects.filter(
                 translations__isnull=True,
             )
@@ -1768,6 +1769,55 @@ class BaseApproveTranslation(View):
 
         p = obj.publish(request.user)
 
+
+        # Send out notifications...
+
+        # ...to the translator
+        Notification.objects.create(
+            notification_type='published',
+            title_text=('{} published your {}'
+                .format(
+                    self.request.user.get_full_name(),
+                    p._meta.verbose_name,
+                ))[:50], # truncate it due to character limit
+            description_text=('Published {}'
+                .format(p)),
+            target_url = p.get_absolute_url(),
+            user=p.translated_by,
+        )
+
+        # ...to the original author
+        Notification.objects.create(
+            notification_type='published',
+            title_text=((
+                '{user} translated your {source_type}'
+                ' to {language}')
+                .format(
+                    user=p.translated_by,
+                    source_type=p.source._meta.verbose_name,
+                    language=(get_language_info(p.language)
+                        .get('name_translated')),
+                ))[:50], # truncate it due to character limit
+            description_text='Translated {}'.format(p.source),
+            target_url=p.get_absolute_url(),
+            user=p.source.author,
+        )
+
+        # ...to the peer reviewers
+        for u in set([c.author for c in p.comments.all()]):
+            Notification.objects.create(
+                notification_type='published',
+                title_text=((
+                    'The translation by {} that you commented on '
+                    'has been published.')
+                    .format(p.translated_by)
+                    )[:50], # truncate it due to character limit
+                    description_text='Translated {}'.format(p.source),
+                target_url=p.get_absolute_url(),
+                user=u,
+            )
+
+        # Create success message and return
         messages.success(request, self.success_message)
         return redirect(p.get_absolute_url())
 


### PR DESCRIPTION
This includes authors of the translation, authors of the original piece, and anyone else who commented on the translation during the review process. Fixes #220.