### PR TITLE
Don't assume answers are published

### DIFF
--- a/dashboard/templates/dashboard/answers/review.html
+++ b/dashboard/templates/dashboard/answers/review.html
@@ -43,7 +43,7 @@
                 <form action="{% url 'dashboard:approve-answer' question_id=question.id answer_id=answer.id %}" method="POST">
                     {% csrf_token %}
                     <p class="publish-info-text">
-                        {% trans 'If you think this answer is complete and adequately answers the question, click the 'Publish' button to publish the answer. If you believe the answer can be improved, leave a comment on the right side.' %}
+                        {% trans 'If you think this answer is complete and adequately answers the question, click the \'Publish\' button to publish the answer. If you believe the answer can be improved, leave a comment on the right side.' %}
                     </p>
                     <button type="submit" class="btn btn-primary btn-block">{% trans 'Publish' %}</button>
                 </form>

--- a/dashboard/templates/dashboard/answers/review.html
+++ b/dashboard/templates/dashboard/answers/review.html
@@ -36,8 +36,8 @@
                 <span>{{ credit.credit_title|capfirst }}</span>
             </div>
         {% endfor %}
-        {% if answer.approved_by %}
-            <p class="published-text"><i class="far fa-check-circle"></i> {% trans 'Published by' %} { answer.approved_by.get_full_name }}</b></p>
+        {% if answer.status == 'published' %}
+            <p class="published-text"><i class="far fa-check-circle"></i> {% trans 'Published by' %} {{ answer.approved_by.get_full_name }}</b></p>
         {% else %}
             {% if request.user != answer.submitted_by %}
                 <form action="{% url 'dashboard:approve-answer' question_id=question.id answer_id=answer.id %}" method="POST">

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -527,8 +527,7 @@ class ReviewAnswersList(SearchView):
     def get_queryset(self, request):
         if 'q' in request.GET:
             query_set = Question.objects.filter(
-                                answers__approved_by__isnull=True,
-                                answers__submitted_by__isnull=False,
+                                answers__status='submitted',
                             ).exclude(
                                 answers__submitted_by=request.user,
                             ).distinct()
@@ -542,8 +541,7 @@ class ReviewAnswersList(SearchView):
             )
         else:
             return Question.objects.filter(
-                            answers__approved_by__isnull=True,
-                            answers__submitted_by__isnull=False,
+                            answers__status='submitted',
                         ).exclude(
                             answers__submitted_by=request.user,
                         ).distinct()
@@ -782,7 +780,7 @@ class ApproveAnswerView(View):
         try:
             answer = Answer.objects.get(
                 pk=answer_id,
-                approved_by__isnull=True)
+                status='submitted')
         except Answer.DoesNotExist:
             raise Http404(_('Answer does not exist'))
 

--- a/public_website/views.py
+++ b/public_website/views.py
@@ -169,7 +169,7 @@ class SearchView(View):
                 questions_queryset = answered_questions
 
             if 'unanswered' in question_categories:
-                unanswered_questions = result.filter(answers__status='published')
+                unanswered_questions = result.exclude(answers__status='published')
                 if type(questions_queryset) is QuerySet:
                     questions_queryset = questions_queryset | unanswered_questions
                 else:

--- a/public_website/views.py
+++ b/public_website/views.py
@@ -165,11 +165,11 @@ class SearchView(View):
             questions_queryset = []
 
             if 'answered' in question_categories:
-                answered_questions = result.filter(answers__approved_by__isnull=False)
+                answered_questions = result.filter(answers__status='published')
                 questions_queryset = answered_questions
 
             if 'unanswered' in question_categories:
-                unanswered_questions = result.filter(answers__approved_by__isnull=True)
+                unanswered_questions = result.filter(answers__status='published')
                 if type(questions_queryset) is QuerySet:
                     questions_queryset = questions_queryset | unanswered_questions
                 else:


### PR DESCRIPTION
Explicitly checks the 'status' of an article in the review page, rather than assuming the answer is published just because `approved_by` is set. The `approved_by` may be accidentally set for other reasons (such as edits pushed via the admin page), and this does not necessarily imply that the article has actually been published.

Fixes the marking of unpublished answers as published, as described by @jr-sawaliram and @dchandrika-tifr earlier today.