### PR TITLE
Preserve filters when submitting search query

### DIFF
--- a/public_website/static/js/script.js
+++ b/public_website/static/js/script.js
@@ -152,6 +152,24 @@ function setupResultsPagination() {
     });
 }
 
+function setupSearchResultsFilterPreservation() {
+    $('form.search').submit(function (e) {
+
+        // prevent form from submitting
+        e.preventDefault()
+
+        // get current param list
+        var params = new URLSearchParams(location.search)
+
+        // set current search string
+        var q = this.querySelector('[name=q]').value
+        params.set('q', q)
+
+        // redirect to the new page, after setting GET parameters
+        location.href = window.location.origin + window.location.pathname + '?' + params.toString()
+    })
+}
+
 function setupSearchResultsFilter() {
     $('.category-option').click(function() {
         if (!$(this).hasClass('.no-fun')) {
@@ -769,6 +787,7 @@ if (
    ) {
     setupResultsPagination();
     setupSearchResultsFilter();
+    setupSearchResultsFilterPreservation();
     setupSearchResultsMobileFilter();
     setupSearchResultsMobileSort();
     setupSearchResultsClearAll();


### PR DESCRIPTION
Since filters are handled via JavaScript and not HTML input elements, they weren't getting preserved on form submission (i.e. on pressing Enter or hitting the Search button).

With this commit, form submission is also handled via JavaScript, bypassing the default HTML behaviour altogether, and preserving filters in a similar manner to the filter button scripts.