### PR TITLE
Fix translations editor

### DIFF
--- a/dashboard/templates/dashboard/translations/article_edit.html
+++ b/dashboard/templates/dashboard/translations/article_edit.html
@@ -16,7 +16,7 @@
 
 {% block tr_translation %}
 <header class="flex">
-  <h1 class="w-100"><input type="text" name="{{ form.title.name }}" value="{{ form.title.value }}" placeholder="{% trans '{{ object.source.tr_title }}' %}" id="{{ form.title.id }}" class="input-plain input-title p-3" /></h1>
+  <h1 class="w-100"><input type="text" name="{{ form.title.name }}" value="{{ form.title.value }}" placeholder="{{ object.source.tr_title }}" id="{{ form.title.id }}" class="input-plain input-title p-3" /></h1>
 </header>
 <div class="bg-white">
   {% include 'dashboard/snippets/richtext_editor.html' with value=form.body.value class='' name=form.body.name %}

--- a/public_website/static/css/style.css
+++ b/public_website/static/css/style.css
@@ -3185,7 +3185,7 @@ figure.image figcaption {
     text-align: justify;
 }
 
-.answer-area .answer-text img {
+.answer-area img {
     max-width: 100%;
 }
 

--- a/public_website/static/js/script.js
+++ b/public_website/static/js/script.js
@@ -740,6 +740,7 @@ if (window.location.pathname.includes('/dashboard/manage-users')) {
 
 if (
     new RegExp("^/dashboard/translate/(articles|answers|questions)/(\\d+/)?\\d+/(review|edit)").test(window.location.pathname) ||
+    new RegExp("^/dashboard/(article|answer)/(\\d+/)?\\d+/translate/from/(\\w+)/to/(\\w+)").test(window.location.pathname) ||
     new RegExp("^/dashboard/question/\\d+/answer/(new|\\d+)").test(window.location.pathname)
 ) {
     initializeCKEditor();


### PR DESCRIPTION
Some tweaks to the translation editor, especially on the Translate Article page.

- [x] Display title in translation (was incorrectly displaying the string `{{object.title}}` instead
- [x] Fix regexp to activate CKEditor even in new article translation pages
- [x] Modify styling to prevent inline images from overflowing their containers