### PR TITLE
Answer Questions: fix crash on query, as well as other minor bugs

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -619,22 +619,21 @@ class ViewQuestionsView(SearchView):
 class AnswerQuestions(SearchView):
     def get_querysets(self, request):
         results = {}
-        if 'q' in request.GET and request.GET.get('q'):
-            query_set = Question.objects.exclude(id__in=Subquery(
-                                    Answer.objects.all().values('question_id')))
-            results['questions'] = query_set.filter(
-                    Q(question_text__search=request.GET.get('q')) |
-                    Q(question_text_english__search=request.GET.get('q')) |
-                    Q(school__search=request.GET.get('q')) |
-                    Q(area__search=request.GET.get('q')) |
-                    Q(state__search=request.GET.get('q')) |
-                    Q(field_of_interest__search=request.GET.get('q')) |
-                    Q(published_source__search=request.GET.get('q'))
-            )
-            return results
-        else:
-            results['questions'] = Question.objects.all()
-            return results
+        results['questions'] = Question.objects.all()
+        return results
+
+    def set_filters(self, params):
+        filters = super().set_filters(params)
+
+        # set question_categories to 'unanswered' by default
+        print(filters['question_categories'])
+        print('hey there')
+        if len(filters['question_categories']) == 0:
+            if 'questions' not in params:
+                filters['question_categories'].append('unanswered')
+
+        self.filters = filters
+        return filters
 
     def get_page_title(self, request):
         return _('Answer Questions')

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -17,7 +17,7 @@ from django.contrib.auth.models import Group
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.translation import get_language_info
 from django.utils.decorators import method_decorator
-from django.db.models import Q
+from django.db.models import Q, Subquery
 from django.core.paginator import Paginator
 from django.contrib.contenttypes.models import ContentType
 from django.views import View

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -637,7 +637,7 @@ class AnswerQuestions(SearchView):
             return results
 
     def get_page_title(self, request):
-        return 'Answer Questions'
+        return _('Answer Questions')
 
     def get_enable_breadcrumbs(self, request):
         return 'Yes'

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -619,7 +619,7 @@ class ViewQuestionsView(SearchView):
 class AnswerQuestions(SearchView):
     def get_querysets(self, request):
         results = {}
-        if 'q' in request.GET:
+        if 'q' in request.GET and request.GET.get('q'):
             query_set = Question.objects.exclude(id__in=Subquery(
                                     Answer.objects.all().values('question_id')))
             results['questions'] = query_set.filter(


### PR DESCRIPTION
- [x] Fix crash on entering a search term in the Answer Questions page
- [x] Treat blank search (pressing Enter on an empty search box) in the same way as an empty search (loading the search page without posting any query at all, blank or otherwise, eg. by clicking on a URL)
- [x] Mark the page title as translatable (`l10n`) to prevent future bugs in the template logic
- [x] Handle "Answered/Unanswered" filter: either ~~(a) hide the filter completely, or~~ (b) set intelligent defaults and ensure the rest works when utilised ~~(TBD; under discussion in Zulip)~~ **decision: go with (b)**