### PR TITLE
View Questions: fix "no results on blank search"

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -592,20 +592,8 @@ class CurateDataset(View):
 class ViewQuestionsView(SearchView):
     def get_querysets(self, request):
         results = {}
-        if 'q' in request.GET:
-            results['questions'] = Question.objects.filter(
-                    Q(question_text__search=request.GET.get('q')) |
-                    Q(question_text_english__search=request.GET.get('q')) |
-                    Q(school__search=request.GET.get('q')) |
-                    Q(area__search=request.GET.get('q')) |
-                    Q(state__search=request.GET.get('q')) |
-                    Q(field_of_interest__search=request.GET.get('q')) |
-                    Q(published_source__search=request.GET.get('q'))
-            )
-            return results
-        else:
-            results['questions'] = Question.objects.all()
-            return results
+        results['questions'] = Question.objects.all()
+        return results
 
     def get_page_title(self, request):
         return _('View Questions')


### PR DESCRIPTION
This was happening because the questions were being filtered twice: once at the ViewQuestionsView and then again at the SearchView. Now, ViewQuestionsView only returns the base queryset, while SearchView handles the query-level filtering (as is the case for other SearchView subclasses)