### PR TITLE
Add translation to user profile

### DIFF
--- a/dashboard/templates/dashboard/translations/answer_review.html
+++ b/dashboard/templates/dashboard/translations/answer_review.html
@@ -75,5 +75,5 @@
 </section>
 {% endblock %}
 {% block edit_button %}
-<a class="btn btn-secondary" href="{% url 'dashboard:edit-submitted-answer-translation' pk=question.id answer=object.id %}">Edit Translation</a>
+<a class="btn btn-secondary" href="{{ object.get_edit_url }}">Edit Translation</a>
 {% endblock %}

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1814,6 +1814,7 @@ class EditAnswerTranslation(BaseEditTranslation):
         answer_text = self.request.POST.get('answer-text')
         if answer_text:
             self.answer.answer_text = answer_text
+            self.answer.language = self.request.POST.get('lang_to') or self.answer.language
             self.answer.save()
 
         # If submitting, mark the answer as submitted for

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -400,10 +400,12 @@ class ManageContentView(View):
         articles = (SubmittedArticle
             .objects.all().order_by('-updated_on'))
         article_translations = (SubmittedArticleTranslation
-            .objects.all()
+            .objects
+            .exclude(translated_by=request.user)
             .order_by('-updated_on'))
         answer_translations = (SubmittedAnswerTranslation
-            .objects.all()
+            .objects
+            .exclude(translated_by=request.user)
             .order_by('-updated_on'))
 
         context = {

--- a/public_website/templates/public_website/user-profile.html
+++ b/public_website/templates/public_website/user-profile.html
@@ -366,11 +366,11 @@
                         <span class="stat-title">Articles<br>Written</span>
                     </div>
                     <div class="user-stat">
-                        <span class="stat-number">0</span>
+                        <span class="stat-number">{{ translations_count }}</span>
                         <span class="stat-title">Things<br>Translated</span>
                     </div>
                 </div>
-                {% if submitted_questions or submitted_answers or submitted_articles or published_articles %}
+                {% if submitted_questions or submitted_answers or submitted_articles or published_articles or submitted_answer_translations or submitted_article_translations %}
                     {% if submitted_questions %}
                         <h2>{% trans 'Questions' %}</h2>
                         {% if selected_user == request.user  %}
@@ -561,6 +561,151 @@
                                     </div>
                                 {% endfor %}
                             {% endif %}
+                        {% endif %}
+                    {% endif %}
+                    {% if submitted_article_translations or submitted_answer_translations or published_article_translations or published_answer_translations %}
+                        <h2>{% trans 'Translations' %}</h2>
+                        {% if selected_user != request.user %}
+                            <p class="small">{% trans 'All content translated by' %} {{ selected_user.first_name }}</p>
+                        {% else %}
+                            <p class="small">{% trans 'All your submitted translations will appear here' %}</p>
+                        {% endif %}
+
+                        <hr class="title-divider">
+
+
+                        {# Answer Translations #}
+
+                        {% if selected_user == request.user %}
+                            {% for submitted_answer in submitted_answer_translations %}
+                                <div class="card sw-shadow">
+                                    <h3 class="low-margin-title">
+                                        <span class="small submitted-date">#{{ submitted_answer.source.question_id.id }}</span> 
+                                        {{ submitted_answer.source.question_id.question_text }}
+                                        <span class="badge badge-secondary">{{ submitted_answer.source.language }} -> {{ submitted_answer.language }}</span>
+                                    </h3>
+                                    <p class="small pending">
+                                        <i class="fas fa-clock"></i> {% trans 'Answer translation under review since' %} {{ submitted_answer.created_on|date:"jS F, Y" }}
+                                    </p>
+                                    <hr>
+                                    <p class="grey-text">
+                                        {{ submitted_answer.answer_text|striptags|truncatechars:200 }}
+                                    </p>
+                                    <div class="card-controls">
+                                            <a class="btn btn-small btn-primary square-ish" href="{{ submitted_answer.get_absolute_url }}">
+                                                Edit Translation
+                                            </a>
+                                            <button class="btn btn-small delete-button open-card-drawer"><i class="far fa-trash-alt"></i> {% trans 'Delete' %}</button>
+                                    </div>
+                                    <div class="card-drawer">
+                                        <form class="inline-block" action="{{ submitted_answer.get_delete_url }}" method="POST">
+                                            {% csrf_token %}
+                                            <span class="drawer-prompt">{% trans 'Are you sure you want to delete this answer?' %}</span>
+                                            <button class="btn btn-small confirm-delete square-ish" type="submit">{% trans 'Yes, Delete' %}</button>
+                                        </form>
+                                        <button class="btn btn-small cancel-delete close-card-drawer">{% trans 'Cancel' %}</button>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        {% endif %}
+
+                        {% for published_answer in published_answer_translations %}
+                            <div class="card sw-shadow">
+                                <h3 class="low-margin-title">
+                                    <span class="small">#{{ published_answer.question_id.id }}</span> 
+                                    {{ published_answer.source.question_id.question_text }}
+                                    <span class="badge badge-secondary">{{ published_answer.source.language }} -> {{ published_answer.language }}</span>
+                                </h3>
+                                <p class="small submitted-date">
+                                    Submitted on {{ published_answer.created_on|date:"jS F, Y" }} | Last edited on {{ published_answer.updated_on|date:"jS F, Y" }}
+                                </p>
+                                <p class="small success">
+                                    <i class="fas fa-check-circle"></i> {% trans 'Answer translation reviewed and published' %}
+                                </p>
+                                <hr>
+                                <p class="grey-text">
+                                    {{ published_answer.answer_text|striptags|truncatechars:200 }}
+                                </p>
+                                <div class="card-controls">
+                                    <a class="btn btn-small btn-primary square-ish" href="{{ published_answer.get_absolute_url }}">
+                                        View Answer
+                                    </a>
+                                </div>
+                            </div>
+                        {% endfor %}
+
+                        {# Article Translations #}
+
+                        {% if selected_user == request.user %}
+                            {% if submitted_article_translations %}
+                                {% for submitted_article in submitted_article_translations %}
+                                    <div class="card sw-shadow">
+                                        <h3 class="low-margin-title">
+                                            {{ submitted_article.title }}
+                                            <span class="badge badge-secondary">{{ submitted_article.source.language }} -> {{ submitted_article.language }}</span>
+                                        </h3>
+                                        <p class="small submitted-date">
+                                            <i class="fas fa-comments"></i>
+                                            Translated from
+                                            <a href="{{ submitted_article.source.get_absolute_url }}" class="grey-link">{{ submitted_article.source.title }}</a>
+                                        </p>
+                                        <p class="small pending">
+                                            <i class="fas fa-clock"></i> {% trans 'Article translation under review since' %} {{ submitted_article.created_on|date:"jS F, Y" }}
+                                        </p>
+                                        <hr>
+                                        <p class="grey-text">
+                                            {{ submitted_article.body|striptags|truncatechars:200 }}
+                                        </p>
+                                        <div class="card-controls">
+                                            <a class="btn btn-small btn-primary square-ish" href="{{ submitted_article.get_absolute_url }}">
+                                                Edit Translation
+                                            </a>
+                                            <button class="btn btn-small delete-button open-card-drawer"><i class="far fa-trash-alt"></i> {% trans 'Delete' %}</button>
+                                        </div>
+                                        <div class="card-drawer">
+                                            <form class="inline-block" action="{{ submitted_article.get_delete_url }}" method="POST">
+                                                {% csrf_token %}
+                                                <span class="drawer-prompt">{% trans 'Are you sure you want to delete this translation?' %}</span>
+                                                <button class="btn btn-small confirm-delete square-ish" type="submit">{% trans 'Yes, Delete' %}</button>
+                                            </form>
+                                            <button class="btn btn-small cancel-delete close-card-drawer">{% trans 'Cancel' %}</button>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            {% endif %}                        
+                        {% endif %}
+
+                        {% if published_article_translations %}
+                            {% for published_article in published_article_translations %}
+                                <div class="card sw-shadow">
+                                    <h3 class="low-margin-title">
+                                        {{ published_article.title }}
+                                        <span class="badge badge-secondary">{{ published_article.source.language }} -> {{ published_article.language }}</span>
+                                    </h3>
+                                    <p class="small published-date">
+                                        <i class="fas fa-comments"></i>
+                                        Translated from
+                                        <a href="{{ published_article.source.get_absolute_url }}" class="grey-link">{{ published_article.source.title }}</a>
+                                    </p>
+                                    <p class="small submitted-date">
+                                        <i class="fas fa-clock"></i> Submitted on {{ published_article.created_on|date:"jS F, Y" }}
+                                    </p>
+                                    {% if selected_user == request.user %}
+                                        <p class="small success">
+                                            <i class="fas fa-check-circle"></i> {% trans 'Article translation reviewed and published' %}
+                                        </p>
+                                    {% endif %}
+                                    <hr>
+                                    <p class="grey-text">
+                                        {{ published_article.body|striptags|truncatechars:200 }}
+                                    </p>
+                                    <div class="card-controls">
+                                        <a class="btn btn-small btn-primary square-ish" href="{{ published_article.get_absolute_url }}">
+                                            View Translation
+                                        </a>
+                                    </div>
+                                </div>
+                            {% endfor %}
                         {% endif %}
                     {% endif %}
                 {% else %}

--- a/public_website/views.py
+++ b/public_website/views.py
@@ -44,6 +44,8 @@ from dashboard.models import (
     DraftArticleTranslation,
     SubmittedArticleTranslation,
     SubmittedAnswerTranslation,
+    PublishedArticleTranslation,
+    PublishedAnswerTranslation,
     AnswerTranslation,
 )
 from sawaliram_auth.models import User, Bookmark, Notification
@@ -574,8 +576,12 @@ class UserProfileView(View):
             submitted_questions = Dataset.objects.filter(submitted_by=user_id)
             submitted_answers = Answer.objects.filter(submitted_by=user_id, status='submitted')
             submitted_articles = SubmittedArticle.objects.filter(author=user_id)
+            submitted_answer_translations = SubmittedAnswerTranslation.objects.filter(translated_by=user_id)
+            submitted_article_translations = SubmittedArticleTranslation.objects.filter(translated_by=user_id)
             published_answers = Answer.objects.filter(submitted_by=user_id, status='published')
             published_articles = PublishedArticle.objects.filter(author=user_id)
+            published_answer_translations = PublishedAnswerTranslation.objects.filter(translated_by=user_id)
+            published_article_translations = PublishedArticleTranslation.objects.filter(translated_by=user_id)
             bookmarked_questions = selected_user.bookmarks.filter(content_type='question')
             bookmarked_articles = selected_user.bookmarks.filter(content_type='article')
             context = {
@@ -593,9 +599,19 @@ class UserProfileView(View):
                 'submitted_questions': submitted_questions,
                 'submitted_answers': submitted_answers,
                 'submitted_articles': submitted_articles,
+                'submitted_answer_translations': submitted_answer_translations,
+                'submitted_article_translations': submitted_article_translations,
                 'published_articles': published_articles,
                 'published_answers': published_answers,
+                'published_answer_translations': published_answer_translations,
+                'published_article_translations': published_article_translations,
                 'answers_count': len(submitted_answers) + len(published_answers),
+                'translations_count': (
+                    submitted_answer_translations.count() +
+                    submitted_article_translations.count() +
+                    published_answer_translations.count() +
+                    published_article_translations.count()
+                ),
                 'bookmarked_questions': bookmarked_questions,
                 'bookmarked_articles': bookmarked_articles,
                 'active_tab': active_tab,


### PR DESCRIPTION
Actually fixes #225 this time (the previous one, #295,was incomplete at the time of merging). Complete list of fixes for this and #295:
- [x] **Set up helper functions to generate "edit" and "delete" translations URLs in a standardised way.** This makes for simpler coding, because one does not have to guess the URL each time; furthermore, if changes are required, they can all be made in one place.
- [x] **Resume displaying draft translations in the user profile.** This was done by #295. It lets a user see the list of drafts they have submittetd.
- [x] **Resume displaying submitted translations in the user profile.** This includes a link to go to the review/edit page for that submission.
- [x] **Resume displaying published translations in the user profile.** This includes a link to view the translated answer, in the given language.
- [x] **Activate translation counter.** Now, the "Things Translated" counter actually shows you the number of things you have submitted and/or published. Draft translations are not included in this count.
- [x] **Hide own translations from Manage Content page.** Earlier, all submitted translations would display in the Manage Content page, including those of the current user. Now, the current user's translations submissions are hidden from the page, since they are in any case not allowed to publish their own submissions.
- [x] **Bugfix: update answer language when new language is selected.** Earlier, the editor would update the question translation language, but leave the answer translation language unchanged, resulting in inconsistent translation languages and causing an error in the review page.
- [x] **Bugfix: use correct ID when deleting answer translations.** This was done by #295. On the Edit Answer Translation page, the "delete" link was incorrectly using the question ID as reference instead of the answer ID. This has now been corrected to use the question ID instead.