### PR TITLE
Hide drafts from Translate Content listing

### DIFF
--- a/dashboard/models.py
+++ b/dashboard/models.py
@@ -212,6 +212,12 @@ class Answer(models.Model):
     translation_model = 'dashboard.PublishedAnswerTranslation'
     translatable_fields = ['answer_text']
 
+    # Statuses
+
+    STATUS_DRAFT = 'draft'
+    STATUS_SUBMITTED = 'submitted'
+    STATUS_PUBLISHED = 'published'
+
     class Meta:
         db_table = 'answer'
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1410,6 +1410,7 @@ class TranslateAnswersList(SearchView):
         if 'q' in request.GET and request.GET.get('q') != '':
             query_set = Question.objects.filter(
                                 answers__isnull=False,
+                                answers__status=Answer.STATUS_PUBLISHED,
                                 answers__translations__isnull=True,
                             ).distinct()
 
@@ -1433,6 +1434,7 @@ class TranslateAnswersList(SearchView):
         else:
             results['questions'] = Question.objects.filter(
                             answers__isnull=False,
+                            answers__status=Answer.STATUS_PUBLISHED,
                             answers__translations__isnull=True,
                         ).distinct()
             results['articles'] = PublishedArticle.objects.filter(

--- a/public_website/templates/public_website/search.html
+++ b/public_website/templates/public_website/search.html
@@ -243,6 +243,7 @@
                 {% endif %}
                 {% if page_title == _('Translate Content') %}
                     {% for answer in question.answers.all %}
+                    {% if answer.status == answer.STATUS_PUBLISHED %}{# We don't want unpublished answers! #}
                     <div class="answer-preview">
                         <h4>Answered by <b>{{ answer.submitted_by.get_full_name }}</b></h4>
                         <p>{{ answer.answer_text|striptags|truncatechars:200 }}</p>
@@ -250,6 +251,7 @@
                             <a href="{% url 'dashboard:translate-answer' source=question.id answer=answer.id %}" class="btn btn-small btn-primary">{% trans 'Translate' %}</a>
                         </div>
                     </div>
+                    {% endif %}
                     {% endfor %}
                 {% endif %}
             </li>


### PR DESCRIPTION
Only published items should be available for translation. This PR filters out the draft and submitted answers from the listing.
