### PR TITLE
Include users in admin interface

### DIFF
--- a/dashboard/admin.py
+++ b/dashboard/admin.py
@@ -13,7 +13,7 @@ from .models import (
     AnswerTranslation,
     TranslatedQuestion,
     AnswerCredit,
-    ArticleCredit
+    ArticleCredit,
 )
 
 

--- a/sawaliram_auth/admin.py
+++ b/sawaliram_auth/admin.py
@@ -1,3 +1,36 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import (
+    User,
+    Profile,
+)
+
+class AnswerCreditInline(admin.StackedInline):
+    model = Profile
+    view_on_site = False
+    show_change_link = True
+
+@admin.register(User)
+class UserAdmin(admin.ModelAdmin):
+
+    list_display = [
+        'email',
+        'get_full_name',
+        'is_active',
+        'created_on',
+    ]
+
+    search_fields = [
+        'email',
+        'first_name',
+        'last_name',
+    ]
+
+    list_filter = [
+        'created_on',
+        'updated_on',
+    ]
+
+    inlines = [
+        AnswerCreditInline,
+    ]


### PR DESCRIPTION
You can now browse/edit users and profiles, as well as update groups and permissions, in the admin interface. Note that **anyone** with access to the admin interface will be able to change/modify users, so we should use the admin permission sparingly!