### PR TITLE
Search count on search page fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 develop-eggs/
 dist/
 downloads/
+suggestions/
 eggs/
 .eggs/
 lib/

--- a/public_website/templates/public_website/search.html
+++ b/public_website/templates/public_website/search.html
@@ -97,7 +97,7 @@
         {% if questions or articles %}
         <div class="head-area">
             <span class="results-count">
-                Showing {% if result_size == 1 %}1{% else %}{{ results.start_index}}-{{ results.end_index }}{% endif %} of {{ result_size }} result{{ result_size|pluralize }}
+                Showing {% if result_size == 1 %}1{% else %}{{ start_index}} - {{ end_index }} {% endif %} of {{ result_size }} result{{ result_size|pluralize }}
             </span>
             <div class="dropdown">
                 <button class="btn sort-by-selector" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="sortOptionSelector">

--- a/public_website/views.py
+++ b/public_website/views.py
@@ -382,7 +382,7 @@ class SearchView(View):
             if (start_index + ITEMS_PER_PAGE <= questions.count()):
                 end_index = start_index + ITEMS_PER_PAGE
             else:
-                end_index = questions.count()
+                end_index = questions.count() + articles.count()
         print(start_index, end_index)
 
 

--- a/public_website/views.py
+++ b/public_website/views.py
@@ -360,10 +360,33 @@ class SearchView(View):
         if page_title == _('Review Answers') or page_title == _('Answer Questions'):
             result_id_list = [id['id'] for id in questions.values('id')]
             request.session['result_id_list'] = result_id_list
+        
 
-        paginator = Paginator(questions, 15)
+        ITEMS_PER_PAGE = 15
 
+        paginator = Paginator(questions, ITEMS_PER_PAGE)
         page = request.GET.get('page', 1)
+
+
+        # Adding the number of questions/articles being shown based on the page number
+        start_index = (int(page)-1)*ITEMS_PER_PAGE + 1
+
+        search_categories = self.filters.get('search_categories', [])
+
+        if ('articles' in search_categories and not 'questions' in search_categories):
+            if (start_index + ITEMS_PER_PAGE <=  articles.count()):
+                end_index = start_index + ITEMS_PER_PAGE
+            else:
+                end_index = articles.count()
+        else:
+            if (start_index + ITEMS_PER_PAGE <= questions.count()):
+                end_index = start_index + ITEMS_PER_PAGE
+            else:
+                end_index = questions.count()
+        print(start_index, end_index)
+
+
+
         questions_page_one = paginator.get_page(page)
 
         # get list of IDs of bookmarked items
@@ -377,7 +400,9 @@ class SearchView(View):
             'page_title': page_title,
             'enable_breadcrumbs': self.get_enable_breadcrumbs(request),
             'questions': questions_page_one,
-            'result_size': questions.count(), #The count for anwsers, etc. will be added to this below
+            'result_size': questions.count(), 
+            'start_index': start_index,
+            'end_index': end_index,
             'subjects': subjects,
             'available_subjects': available_subjects,
             'states': states,


### PR DESCRIPTION
This fixes [#363](https://github.com/sawaliram/sawaliram/issues/363)

**Bug**:
Previously search count was not working properly for both questions and articles.
and in **PR**  [364](https://github.com/sawaliram/sawaliram/pull/364) articles count was not properly working.


**Description**:
Fixes `result count` like showing 1-16 etc. on `/search` page.