### PR TITLE
Breadcrumb integrated in translation interface

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1604,7 +1604,7 @@ class BaseStartTranslation(FormView):
         form = super().get_form()
 
         # Decide language options
-        available_languages = self.source.list_available_languages()
+        available_languages = self.answer.list_available_languages()
         unavailable_languages = []
         for l in settings.CONTENT_LANGUAGES:
             if l not in available_languages:
@@ -1715,20 +1715,6 @@ class CreateAnswerTranslation(BaseStartTranslation):
 
         return context
 
-    def get_form(self):
-            form = super().get_form()
-
-            # Decide language options     
-            available_languages = self.answer.list_available_languages()
-            unavailable_languages = []
-            for l in settings.CONTENT_LANGUAGES:
-                if l not in available_languages:
-                    unavailable_languages.append(l)
-
-            form.fields.get('lang_from').choices = available_languages
-            form.fields.get('lang_to').choices = unavailable_languages
-
-            return form
 
     def get_enable_breadcrumbs(self):
         """

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1604,7 +1604,7 @@ class BaseStartTranslation(FormView):
         form = super().get_form()
 
         # Decide language options
-        available_languages = self.answer.list_available_languages()
+        available_languages = self.source.list_available_languages()
         unavailable_languages = []
         for l in settings.CONTENT_LANGUAGES:
             if l not in available_languages:
@@ -1645,6 +1645,8 @@ class BaseStartTranslation(FormView):
             source=self.source.id,
         )
 
+    
+
 class CreateArticleTranslation(BaseStartTranslation):
     '''
     Initiate the translation of an article
@@ -1654,6 +1656,26 @@ class CreateArticleTranslation(BaseStartTranslation):
     answer_model = Answer
     template_name = 'dashboard/articles/start_translation.html'
     success_view = 'dashboard:edit-article-translation'
+
+    def get_context_data(self):
+        context = super().get_context_data()
+        context['enable_breadcrumbs'] =self.get_enable_breadcrumbs()
+        context['page_title'] = self.get_page_title()
+
+        return context
+
+
+    def get_enable_breadcrumbs(self):
+        """
+        Returns the setting to enable breadcrumbs
+        """
+        return 'Yes'
+
+
+    def get_page_title(self):
+
+        return _('Translate Article')
+
 
 class CreateAnswerTranslation(BaseStartTranslation):
     '''
@@ -1687,8 +1709,38 @@ class CreateAnswerTranslation(BaseStartTranslation):
     def get_context_data(self):
         context = super().get_context_data()
         context['answer'] = self.answer
+        context['enable_breadcrumbs'] =self.get_enable_breadcrumbs()
+        context['page_title'] = self.get_page_title()
+
 
         return context
+
+    def get_form(self):
+            form = super().get_form()
+
+            # Decide language options     
+            available_languages = self.answer.list_available_languages()
+            unavailable_languages = []
+            for l in settings.CONTENT_LANGUAGES:
+                if l not in available_languages:
+                    unavailable_languages.append(l)
+
+            form.fields.get('lang_from').choices = available_languages
+            form.fields.get('lang_to').choices = unavailable_languages
+
+            return form
+
+    def get_enable_breadcrumbs(self):
+        """
+        Returns the setting to enable breadcrumbs
+        """
+        return 'Yes'
+
+
+    def get_page_title(self):
+
+        return _('Translate Answer')
+
 
 # Translate Article
 class BaseEditTranslation(UpdateView):
@@ -1869,6 +1921,26 @@ class EditArticleTranslation(BaseEditTranslation):
     template_name = 'dashboard/translations/article_edit.html'
     view_name = 'dashboard:edit-article-translation'
 
+
+    def get_context_data(self):
+        context = super().get_context_data()
+        context['enable_breadcrumbs'] =self.get_enable_breadcrumbs()
+        context['page_title'] = self.get_page_title()
+
+        return context
+
+
+    def get_enable_breadcrumbs(self):
+        """
+        Returns the setting to enable breadcrumbs
+        """
+        return 'Yes'
+
+
+    def get_page_title(self):
+
+        return _('Edit Article Translation')
+
 @method_decorator(login_required, name='dispatch')
 @method_decorator(permission_required('volunteers'), name='dispatch')
 class EditAnswerTranslation(BaseEditTranslation):
@@ -1877,6 +1949,7 @@ class EditAnswerTranslation(BaseEditTranslation):
     fields = Question.translatable_fields
     template_name = 'dashboard/translations/answer_edit.html'
     view_name = 'dashboard:edit-answer-translation'
+
 
     def get_object(self):
         '''
@@ -1931,6 +2004,9 @@ class EditAnswerTranslation(BaseEditTranslation):
 
         context = super().get_context_data(*args, **kwargs)
         context['answer'] = self.answer
+        context['enable_breadcrumbs'] =self.get_enable_breadcrumbs()
+        context['page_title'] = self.get_page_title()
+
         return context
 
     def form_valid(self, form):
@@ -1952,6 +2028,17 @@ class EditAnswerTranslation(BaseEditTranslation):
 
         return response
 
+
+    def get_enable_breadcrumbs(self):
+        """
+        Returns the setting to enable breadcrumbs
+        """
+        return 'Yes'
+
+
+    def get_page_title(self):
+
+        return _('Edit Answer Translation')
 
 @method_decorator(login_required, name='dispatch')
 @method_decorator(permission_required('volunteers'), name='dispatch')

--- a/public_website/templates/public_website/base.html
+++ b/public_website/templates/public_website/base.html
@@ -206,6 +206,23 @@
                         {% if page_title == 'Review Article' %}
                             <a href="{% url 'dashboard:manage-content' %}">{% trans 'Manage Content' %}</a> >
                         {% endif %}
+
+                        {% if page_title == 'Translate Answer' %}
+                            <a href="{% url 'dashboard:translate-answers' %}">{% trans 'Translate Content' %}</a> >
+                        {% endif %}
+
+                        {% if page_title == 'Translate Article' %}
+                            <a href="{% url 'dashboard:translate-answers' %}">{% trans 'Translate Content' %}</a> >
+                        {% endif %}
+
+                        {% if page_title == 'Edit Answer Translation' %}
+                            <a href="{% url 'dashboard:translate-answers' %}">{% trans 'Translate Content' %}</a> >
+                        {% endif %}
+
+                        {% if page_title == 'Edit Article Translation' %}
+                            <a href="{% url 'dashboard:translate-answers' %}">{% trans 'Translate Content' %}</a> >
+                        {% endif %}
+
                     {% endif %}
                     {{ page_title }}
                 </p>


### PR DESCRIPTION
**Bug:**

As per issue [#375](https://github.com/sawaliram/sawaliram/issues/375) breadcrumb is to be integrated on translation interface.

**Description:**

This fixes [#375](https://github.com/sawaliram/sawaliram/issues/375)
Breadcrumb is integrated.

![99](https://user-images.githubusercontent.com/64596494/119609050-9302f500-be14-11eb-85e8-2a6c67e89ff3.PNG)

