### PR TITLE
Hyperlinks removed in About page

### DIFF
--- a/public_website/templates/public_website/about.html
+++ b/public_website/templates/public_website/about.html
@@ -18,13 +18,13 @@
             gathering in the village of Rasulia, in the Hoshangabad District of Madhya Pradesh State. 
             They wished to develop an active, inquiring and experiment-based science program, a curriculum that 
             was rooted in rural India.Their efforts led to the landmark 'Hoshangabad Science Teaching 
-            Program <a href="https://www.eklavya.in/past-work-top/programmes-past-top/hstp">(HSTP)</a>', one that was implemented in the next 30 years over large tracts of the State.' 
+            Program (HSTP)', one that was implemented in the next 30 years over large tracts of the State.' 
          {% endblocktrans %}
     </p>
     
     <P> 
         {% blocktrans %}
-            HSTP and its <a href="https://www.eklavya.in/past-work-top/programmes-past-top/hstp/224-workbook">'Bal Vaigyanik'</a> ('Child Scientist' in Hindi) textbooks offered children many opportunities t
+            HSTP and its 'Bal Vaigyanik' ('Child Scientist' in Hindi) textbooks offered children many opportunities t
             o observe, experiment and investigate their surroundings.  As a result children came up with a host of 
             intriguing questions which they and their teachers naturally lacked the resources to handle. 
             Thus it was that 'Sawaliram' was born. The year was 1978. 
@@ -47,7 +47,7 @@
             with an aim to develop scientific and technical literature in Indian languages. By the start of the 
             1970s the 'Kerala Shastra Sahitya Parishad (KSSP)' was publishing magazines for children and responding 
             to their questions. KSSP's ideal of a 'People’s Science Movement' was adopted by popular groups in other 
-            States of India, leading in 1988 to the <a href="https://aipsn.net/resources-2/">'All India People's Science Network'</a>, in which many groups have 
+            States of India, leading in 1988 to the 'All India People's Science Network', in which many groups have 
             run their own Q&A programs in different Indian languages. 
         {% endblocktrans %}
     </p>


### PR DESCRIPTION
Hyperlinks are removed in the 'About' text to simplify the blocks for translation.