### PR TITLE
Restoring xlrd to its previous version == 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,4 @@ urllib3==1.26.5
 vine==5.0.0
 whitenoise==5.2.0
 wrapt==1.12.1
-xlrd==2.0.1
+xlrd==1.2.0


### PR DESCRIPTION
fixes #433 