### PR TITLE
Fixes the compressor error at analytics page.

### DIFF
--- a/public_website/templates/public_website/base.html
+++ b/public_website/templates/public_website/base.html
@@ -298,9 +298,11 @@
         {% compress js %}
         <script src="{% static 'js/jquery-3.3.1.min.js' %}"></script>
         <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
-        {% block script_includes %} {% endblock %}
         <script src="{% static 'js/script.js' %}"></script>
         {% endcompress %}
+        
+        {% block script_includes %} {% endblock %}
+
         
         {% block footer %}{% endblock %}
 


### PR DESCRIPTION
Fixes the compressor error at analytics page.

> error:

```
Exception Type: UncompressableFileError at /analytics/
Exception Value: 'https://d3js.org/d3.v3.min.js' isn't accessible via COMPRESS_URL ('/static/') and can't be compressed

```