### PR TITLE
Reactivate CKEditor

### DIFF
--- a/public_website/templates/public_website/base.html
+++ b/public_website/templates/public_website/base.html
@@ -295,13 +295,13 @@
         </div>
 
 
+        {% block script_includes %} {% endblock %}
+
         {% compress js %}
         <script src="{% static 'js/jquery-3.3.1.min.js' %}"></script>
         <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
         <script src="{% static 'js/script.js' %}"></script>
         {% endcompress %}
-        
-        {% block script_includes %} {% endblock %}
 
         
         {% block footer %}{% endblock %}


### PR DESCRIPTION
CKEditor wasn't running because the script_includes block (from where the main CKEditor script was being loaded) had come below the "script.js" include block. This means "script.js" was trying to start CKEditor before CKEditor had properly loaded.

Moving the script_includes block to be *before* the "script.js" rather than after should fix the issue.